### PR TITLE
Fix: Reset search when input is cleared

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -919,8 +919,14 @@ export default function Table({
   const handleSearchChange = (searchValue: string) => {
     if (tableType === 'countries') {
       setLocalSearchTermCountry(searchValue)
+      if (searchValue === '') {
+        setCountrySearchTerm('')
+      }
     } else {
       setLocalSearchTerm(searchValue)
+      if (searchValue === '') {
+        setSearchTerm('')
+      }
     }
   }
 


### PR DESCRIPTION
Fixes [#63](https://github.com/oceanprotocol/nodes-dashboard/issues/63).

Changes proposed in this PR:

- Fix: Reset search when input is cleared
- 
- 