### PR TITLE
fix: use ES envs data as fallback in node details page

### DIFF
--- a/src/components/node-details/environments.tsx
+++ b/src/components/node-details/environments.tsx
@@ -5,16 +5,20 @@ import { CHAIN_ID } from '@/constants/chains';
 import { getSupportedTokens } from '@/constants/tokens';
 import { useP2P } from '@/contexts/P2PContext';
 import { ComputeEnvironment, EnvNodeInfo } from '@/types/environments';
-import { Collapse } from '@mui/material';
+import { Collapse, Tooltip } from '@mui/material';
 import React, { useMemo, useState } from 'react';
 import styles from './environments.module.css';
+import { formatDateTime } from '@/utils/formatters'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 type EnvironmentsProps = {
   envs: ComputeEnvironment[];
   nodeInfo: EnvNodeInfo;
+  envsTimestamp?: number;
+  staleEnvData?: boolean;
 };
 
-const Environments: React.FC<EnvironmentsProps> = ({ envs, nodeInfo }) => {
+const Environments: React.FC<EnvironmentsProps> = ({ envs, nodeInfo, envsTimestamp, staleEnvData }) => {
   const { isReady } = useP2P();
 
   const [showingMore, setShowingMore] = useState(false);
@@ -47,7 +51,10 @@ const Environments: React.FC<EnvironmentsProps> = ({ envs, nodeInfo }) => {
 
   return (
     <Card direction="column" padding="md" radius="lg" shadow="black" spacing="md" variant="glass-shaded">
-      <h3>Environments</h3>
+      <div style={{display: 'flex', justifyContent: 'space-between'}}>
+        <h3>Environments </h3>
+        { staleEnvData && envsTimestamp ? <span><Tooltip title={`Data possibly stale, last update: ${formatDateTime(envsTimestamp / 1000)}`}><InfoOutlinedIcon /></Tooltip></span> : null}
+      </div>
       <div className={styles.list}>
         {!isReady ? (
           <div>Fetching data...</div>

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -45,19 +45,24 @@ const NodeDetailsPage: React.FC = () => {
    * Check node connectivity by p2p and direct node command by loading its envs
    */
   useEffect(() => {
-    if (!node) {
-      return;
-    }
+    if (!node) return;
+
     const peerId = node.id ?? node.nodeId;
-    if (isP2PReady) {
-      getEnvsP2P(node.currentAddrs?.length ? node.currentAddrs : peerId)
-        .then((envs) => {
-          setNodeEnvs((prev) => (prev.length > 0 ? prev : envs));
-          setConnectedP2P(true);
-        })
-        .catch(() => setConnectedP2P(false));
-    }
-    directNodeCommand({
+
+    const p2pPromise = isP2PReady
+      ? getEnvsP2P(node.currentAddrs?.length ? node.currentAddrs : peerId)
+          .then((envs) => {
+            setNodeEnvs((prev) => (prev.length > 0 ? prev : envs));
+            setConnectedP2P(true);
+            return envs;
+          })
+          .catch(() => {
+            setConnectedP2P(false);
+            return [];
+          })
+      : Promise.resolve([]);
+
+    const directPromise = directNodeCommand({
       command: 'getComputeEnvironments',
       body: {},
       multiaddrs: node.currentAddrs,
@@ -68,22 +73,25 @@ const NodeDetailsPage: React.FC = () => {
           const envs = await response.json();
           setNodeEnvs((prev) => (prev.length > 0 ? prev : envs));
           setConnectedDirectNodeCommand(true);
-        } catch (error) {
+          return envs;
+        } catch {
           setConnectedDirectNodeCommand(false);
+          return [];
         }
       })
-      .catch(() => setConnectedDirectNodeCommand(false));
+      .catch(() => {
+        setConnectedDirectNodeCommand(false);
+        return [];
+      });
 
-      if (nodeEnvs.length === 0 && node.computeEnvironments?.environments && node.computeEnvironments.environments.length > 0) {
-        console.log("in here")
-        setNodeEnvs(node.computeEnvironments.environments)
-        setMaybeStaleEnvData(true)
+    Promise.all([p2pPromise, directPromise]).then(([p2pEnvs, directEnvs]) => {
+      const gotEnvs = p2pEnvs.length > 0 || directEnvs.length > 0;
+      if (!gotEnvs && node.computeEnvironments?.environments && node.computeEnvironments.environments.length > 0) {
+        setNodeEnvs(node.computeEnvironments.environments);
+        setMaybeStaleEnvData(true);
       }
+    });
   }, [node, isP2PReady, sendCommand, getEnvsP2P]);
-
-  useEffect(() => {
-      console.log({ nodeEnvs, esEnvs: node?.computeEnvironments })
-  }, [nodeEnvs])
 
   useEffect(() => {
     if (node) {

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -99,9 +99,9 @@ const NodeDetailsPage: React.FC = () => {
           <JobsRevenueStats envs={nodeEnvs} />
           <BenchmarkJobs />
           <Environments
-            envs={nodeEnvs ?? node.computeEnvironments?.environments}
+            envs={nodeEnvs?.length !== 0 ? nodeEnvs : node.computeEnvironments?.environments}
             envsTimestamp={node.computeEnvironments?.timestamp}
-            staleEnvData={!nodeEnvs && !!node.computeEnvironments?.environments}
+            staleEnvData={(nodeEnvs?.length === 0 || !nodeEnvs) && node.computeEnvironments?.environments?.length > 0}
             nodeInfo={{
               friendlyName: node.friendlyName,
               id: node.id ?? node.nodeId,

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -75,6 +75,10 @@ const NodeDetailsPage: React.FC = () => {
   }, [node, isP2PReady, sendCommand, getEnvsP2P]);
 
   useEffect(() => {
+      console.log({ nodeEnvs, esEnvs: node.computeEnvironments })
+  }, [nodeEnvs])
+
+  useEffect(() => {
     if (node) {
       fetchUnbanRequests(node.id ?? node.nodeId);
     }

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -24,6 +24,7 @@ const NodeDetailsPage: React.FC = () => {
   const { unbanRequests, fetchUnbanRequests } = useUnbanRequestsContext();
 
   const [connectedP2P, setConnectedP2P] = useState<boolean | null>(null);
+  const [maybeStaleEnvData, setMaybeStaleEnvData] = useState<boolean | undefined>(undefined);
   const [connectedDirectNodeCommand, setConnectedDirectNodeCommand] = useState<boolean | null>(null);
   const [nodeEnvs, setNodeEnvs] = useState<ComputeEnvironment[]>([]);
 
@@ -72,6 +73,11 @@ const NodeDetailsPage: React.FC = () => {
         }
       })
       .catch(() => setConnectedDirectNodeCommand(false));
+
+      if (nodeEnvs.length === 0 && node.computeEnvironments?.environments && node.computeEnvironments.environments.length > 0) {
+        setNodeEnvs(node.computeEnvironments.environments)
+        setMaybeStaleEnvData(true)
+      }
   }, [node, isP2PReady, sendCommand, getEnvsP2P]);
 
   useEffect(() => {
@@ -99,9 +105,9 @@ const NodeDetailsPage: React.FC = () => {
           <JobsRevenueStats envs={nodeEnvs} />
           <BenchmarkJobs />
           <Environments
-            envs={nodeEnvs?.length !== 0 ? nodeEnvs : node.computeEnvironments?.environments}
+            envs={nodeEnvs}
             envsTimestamp={node.computeEnvironments?.timestamp}
-            staleEnvData={(nodeEnvs?.length === 0 || !nodeEnvs) && node.computeEnvironments?.environments?.length > 0}
+            staleEnvData={maybeStaleEnvData}
             nodeInfo={{
               friendlyName: node.friendlyName,
               id: node.id ?? node.nodeId,

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -47,6 +47,7 @@ const NodeDetailsPage: React.FC = () => {
   useEffect(() => {
     if (!node) return;
     setMaybeStaleEnvData(undefined);
+    setNodeEnvs([]);
     const peerId = node.id ?? node.nodeId;
 
     const p2pPromise = isP2PReady

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -46,7 +46,7 @@ const NodeDetailsPage: React.FC = () => {
    */
   useEffect(() => {
     if (!node) return;
-
+    setMaybeStaleEnvData(undefined);
     const peerId = node.id ?? node.nodeId;
 
     const p2pPromise = isP2PReady

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -33,9 +33,65 @@ const NodeDetailsPage: React.FC = () => {
       return selectedNode;
     }
     return null;
+  }, [params?.nodeId, selectedNode]);
+
+  useEffect(() => {
+    if (!node) {
+      fetchNode(params?.nodeId);
+    }
+  }, [params?.nodeId, fetchNode, node]);
+
+  /**
+   * Check node connectivity by p2p and direct node command by loading its envs
+   */
+  useEffect(() => {
     if (!node) return;
     setMaybeStaleEnvData(undefined);
-    setNodeEnvs([]);
+    const peerId = node.id ?? node.nodeId;
+
+    const p2pPromise = isP2PReady
+      ? getEnvsP2P(node.currentAddrs?.length ? node.currentAddrs : peerId)
+          .then((envs) => {
+            setNodeEnvs((prev) => (prev.length > 0 ? prev : envs));
+            setConnectedP2P(true);
+            return envs;
+          })
+          .catch(() => {
+            setConnectedP2P(false);
+            return [];
+          })
+      : Promise.resolve([]);
+
+    const directPromise = directNodeCommand({
+      command: 'getComputeEnvironments',
+      body: {},
+      multiaddrs: node.currentAddrs,
+      peerId,
+    })
+      .then(async (response) => {
+        try {
+          const envs = await response.json();
+          setNodeEnvs((prev) => (prev.length > 0 ? prev : envs));
+          setConnectedDirectNodeCommand(true);
+          return envs;
+        } catch {
+          setConnectedDirectNodeCommand(false);
+          return [];
+        }
+      })
+      .catch(() => {
+        setConnectedDirectNodeCommand(false);
+        return [];
+      });
+
+    Promise.all([p2pPromise, directPromise]).then(([p2pEnvs, directEnvs]) => {
+      const gotEnvs = p2pEnvs.length > 0 || directEnvs.length > 0;
+      if (!gotEnvs && node.computeEnvironments?.environments && node.computeEnvironments.environments.length > 0) {
+        setNodeEnvs(node.computeEnvironments.environments);
+        setMaybeStaleEnvData(true);
+      }
+    });
+  }, [node, isP2PReady, sendCommand, getEnvsP2P]);
 
   useEffect(() => {
     if (node) {

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -95,7 +95,9 @@ const NodeDetailsPage: React.FC = () => {
           <JobsRevenueStats envs={nodeEnvs} />
           <BenchmarkJobs />
           <Environments
-            envs={nodeEnvs}
+            envs={nodeEnvs ?? node.computeEnvironments?.environments}
+            envsTimestamp={node.computeEnvironments?.timestamp}
+            staleEnvData={!nodeEnvs && !!node.computeEnvironments?.environments}
             nodeInfo={{
               friendlyName: node.friendlyName,
               id: node.id ?? node.nodeId,

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -75,7 +75,7 @@ const NodeDetailsPage: React.FC = () => {
   }, [node, isP2PReady, sendCommand, getEnvsP2P]);
 
   useEffect(() => {
-      console.log({ nodeEnvs, esEnvs: node.computeEnvironments })
+      console.log({ nodeEnvs, esEnvs: node?.computeEnvironments })
   }, [nodeEnvs])
 
   useEffect(() => {

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -33,65 +33,9 @@ const NodeDetailsPage: React.FC = () => {
       return selectedNode;
     }
     return null;
-  }, [params?.nodeId, selectedNode]);
-
-  useEffect(() => {
-    if (!node) {
-      fetchNode(params?.nodeId);
-    }
-  }, [params?.nodeId, fetchNode, node]);
-
-  /**
-   * Check node connectivity by p2p and direct node command by loading its envs
-   */
-  useEffect(() => {
     if (!node) return;
     setMaybeStaleEnvData(undefined);
-    const peerId = node.id ?? node.nodeId;
-
-    const p2pPromise = isP2PReady
-      ? getEnvsP2P(node.currentAddrs?.length ? node.currentAddrs : peerId)
-          .then((envs) => {
-            setNodeEnvs((prev) => (prev.length > 0 ? prev : envs));
-            setConnectedP2P(true);
-            return envs;
-          })
-          .catch(() => {
-            setConnectedP2P(false);
-            return [];
-          })
-      : Promise.resolve([]);
-
-    const directPromise = directNodeCommand({
-      command: 'getComputeEnvironments',
-      body: {},
-      multiaddrs: node.currentAddrs,
-      peerId,
-    })
-      .then(async (response) => {
-        try {
-          const envs = await response.json();
-          setNodeEnvs((prev) => (prev.length > 0 ? prev : envs));
-          setConnectedDirectNodeCommand(true);
-          return envs;
-        } catch {
-          setConnectedDirectNodeCommand(false);
-          return [];
-        }
-      })
-      .catch(() => {
-        setConnectedDirectNodeCommand(false);
-        return [];
-      });
-
-    Promise.all([p2pPromise, directPromise]).then(([p2pEnvs, directEnvs]) => {
-      const gotEnvs = p2pEnvs.length > 0 || directEnvs.length > 0;
-      if (!gotEnvs && node.computeEnvironments?.environments && node.computeEnvironments.environments.length > 0) {
-        setNodeEnvs(node.computeEnvironments.environments);
-        setMaybeStaleEnvData(true);
-      }
-    });
-  }, [node, isP2PReady, sendCommand, getEnvsP2P]);
+    setNodeEnvs([]);
 
   useEffect(() => {
     if (node) {

--- a/src/components/node-details/node-details-page.tsx
+++ b/src/components/node-details/node-details-page.tsx
@@ -75,6 +75,7 @@ const NodeDetailsPage: React.FC = () => {
       .catch(() => setConnectedDirectNodeCommand(false));
 
       if (nodeEnvs.length === 0 && node.computeEnvironments?.environments && node.computeEnvironments.environments.length > 0) {
+        console.log("in here")
         setNodeEnvs(node.computeEnvironments.environments)
         setMaybeStaleEnvData(true)
       }

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -1,3 +1,5 @@
+import { ComputeEnvironment } from '@/types/environments'
+
 export type AnyNode = any;
 
 export type BanStatusResponse = {
@@ -44,6 +46,7 @@ export type Node = {
     bandwidth: number;
     totalScore: number;
   };
+  computeEnvironments?: { environments: ComputeEnvironment[]; timestamp: number };
   latestGpuScore: number;
   latestCpuScore: number;
   latestTotalScore: number;


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- use environments from ES as fallback data for node details `Environments` section