### PR TITLE
filter locks - only show user's locks

### DIFF
--- a/src/lib/use-escrow-data.ts
+++ b/src/lib/use-escrow-data.ts
@@ -73,7 +73,14 @@ export const useEscrowData = (): UseEscrowDataReturn => {
           return Promise.all(
             allAuthorizations.map(async (authorizations) => {
               const spender = authorizations.payee;
-              const locks = await ocean.getLocks(token.address, account.address!, spender);
+              // Contract getLocks filters payer/token with OR, so it leaks other payers' locks and
+              // other tokens. Narrow to this user's locks for this token client-side.
+              const allLocks = await ocean.getLocks(token.address, account.address!, spender);
+              const locks = allLocks.filter(
+                (lock) =>
+                  lock.payer.toLowerCase() === account.address!.toLowerCase() &&
+                  lock.token.toLowerCase() === token.address.toLowerCase()
+              );
               return {
                 tokenSymbol: token.symbol,
                 tokenAddress: token.address,


### PR DESCRIPTION
Fixes #532  .

Changes proposed in this PR:

- 
- 
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Escrow locks now show only the entries that belong to the current user and selected token, reducing unrelated results in lock lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->