### PR TITLE
Escrow page improvements

### DIFF
--- a/src/components/button/copy-button.tsx
+++ b/src/components/button/copy-button.tsx
@@ -32,7 +32,7 @@ const CopyButton: React.FC<CopyButtonProps> = ({
     <Button
       className={className}
       color={color}
-      contentBefore={copied ? <CheckIcon /> : <ContentCopyIcon />}
+      contentBefore={copied ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
       onClick={handleClick}
       size={size}
       variant={variant}

--- a/src/components/escrow/authorization-form.tsx
+++ b/src/components/escrow/authorization-form.tsx
@@ -79,7 +79,7 @@ const AuthorizationForm = ({
           value={formik.values.maxLockSeconds}
         />
         <Input
-          endAdornment="locks"
+          endAdornment="jobs"
           errorText={formik.touched.maxLockCount && formik.errors.maxLockCount ? formik.errors.maxLockCount : undefined}
           hint="Max lock count"
           label="Max concurrent jobs"

--- a/src/components/escrow/authorization-form.tsx
+++ b/src/components/escrow/authorization-form.tsx
@@ -60,6 +60,7 @@ const AuthorizationForm = ({
           name="maxLockedAmount"
           onBlur={formik.handleBlur}
           onChange={formik.handleChange}
+          size="sm"
           step="any"
           type="number"
           value={formik.values.maxLockedAmount}
@@ -73,16 +74,19 @@ const AuthorizationForm = ({
           name="maxLockSeconds"
           onBlur={formik.handleBlur}
           onChange={formik.handleChange}
+          size="sm"
           type="number"
           value={formik.values.maxLockSeconds}
         />
         <Input
           endAdornment="locks"
           errorText={formik.touched.maxLockCount && formik.errors.maxLockCount ? formik.errors.maxLockCount : undefined}
-          label="Max lock count"
+          hint="Max lock count"
+          label="Max concurrent jobs"
           name="maxLockCount"
           onBlur={formik.handleBlur}
           onChange={formik.handleChange}
+          size="sm"
           type="number"
           value={formik.values.maxLockCount}
         />

--- a/src/components/escrow/create-authorization-modal.tsx
+++ b/src/components/escrow/create-authorization-modal.tsx
@@ -89,14 +89,15 @@ const CreateAuthorizationModal = ({
         setFieldError('nodeId', 'Node not found');
         return null;
       }
-      const consumer = node.computeEnvironments?.environments?.find((env) => env.consumerAddress)?.consumerAddress;
+      const consumer =
+        node.address ?? node.computeEnvironments?.environments?.find((env) => env.consumerAddress)?.consumerAddress;
       if (!consumer) {
-        setFieldError('nodeId', 'Node has no compute environment with a consumer address');
+        setFieldError('nodeId', 'Could not resolve ETH address for this node');
         return null;
       }
       return consumer;
     } catch (error) {
-      console.error('Error resolving node consumer address: ', error);
+      console.error('Could not resolve ETH address for this node: ', error);
       setFieldError('nodeId', 'Failed to fetch node');
       return null;
     }
@@ -114,11 +115,12 @@ const CreateAuthorizationModal = ({
       <form className={styles.root} onSubmit={formik.handleSubmit}>
         <Input
           errorText={formik.touched.nodeId && formik.errors.nodeId ? formik.errors.nodeId : undefined}
-          label="Node ID"
+          label="Node peer ID"
           name="nodeId"
           onBlur={formik.handleBlur}
           onChange={formik.handleChange}
           placeholder="Node peer ID"
+          size="sm"
           type="text"
           value={formik.values.nodeId}
         />
@@ -134,6 +136,7 @@ const CreateAuthorizationModal = ({
             name="maxLockedAmount"
             onBlur={formik.handleBlur}
             onChange={formik.handleChange}
+            size="sm"
             step="any"
             type="number"
             value={formik.values.maxLockedAmount}
@@ -147,18 +150,21 @@ const CreateAuthorizationModal = ({
             name="maxLockSeconds"
             onBlur={formik.handleBlur}
             onChange={formik.handleChange}
+            size="sm"
             type="number"
             value={formik.values.maxLockSeconds}
           />
           <Input
-            endAdornment="locks"
+            endAdornment="jobs"
             errorText={
               formik.touched.maxLockCount && formik.errors.maxLockCount ? formik.errors.maxLockCount : undefined
             }
-            label="Max lock count"
+            hint="Max lock count"
+            label="Max concurrent jobs"
             name="maxLockCount"
             onBlur={formik.handleBlur}
             onChange={formik.handleChange}
+            size="sm"
             type="number"
             value={formik.values.maxLockCount}
           />

--- a/src/components/escrow/edit-authorization-modal.tsx
+++ b/src/components/escrow/edit-authorization-modal.tsx
@@ -1,8 +1,11 @@
 import Button from '@/components/button/button';
+import CopyButton from '@/components/button/copy-button';
 import AuthorizationForm from '@/components/escrow/authorization-form';
+import styles from '@/components/escrow/escrow-token-panel.module.css';
 import Modal from '@/components/modal/modal';
 import { useAuthorizeTokens } from '@/lib/use-authorize-tokens';
 import { EscrowSpenderInfo } from '@/lib/use-escrow-data';
+import { formatWalletAddress } from '@/utils/formatters';
 
 type EditAuthorizationModalProps = {
   isOpen: boolean;
@@ -17,7 +20,36 @@ const EditAuthorizationModal = ({ isOpen, onClose, onSuccess, spender }: EditAut
   const { authorizations, tokenAddress, tokenSymbol } = spender;
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Edit authorization" width="sm">
+    <Modal isOpen={isOpen} onClose={onClose} title="Edit authorization per node" width="sm">
+      <div>
+        <h4>{spender.nodeFriendlyName ?? (spender.nodeId ? 'Unnamed node' : 'Unknown node')}</h4>
+        {spender.nodeId && (
+          <div className={styles.copyRow}>
+            <strong>Peer ID:</strong>
+            <span className={styles.hash}>{formatWalletAddress(spender.nodeId)}</span>
+            <CopyButton
+              color="accent1"
+              contentToCopy={spender.nodeId}
+              label=""
+              labelCopied=""
+              size="sm"
+              variant="transparent"
+            />
+          </div>
+        )}
+        <div className={styles.copyRow}>
+          <strong>ETH Address:</strong>
+          <span className={styles.hash}>{formatWalletAddress(spender.spender)}</span>
+          <CopyButton
+            color="accent1"
+            contentToCopy={spender.spender}
+            label=""
+            labelCopied=""
+            size="sm"
+            variant="transparent"
+          />
+        </div>
+      </div>
       <AuthorizationForm
         initialValues={{
           maxLockedAmount: Number(authorizations.maxLockedAmount),

--- a/src/components/escrow/escrow-token-panel.module.css
+++ b/src/components/escrow/escrow-token-panel.module.css
@@ -154,14 +154,6 @@
   gap: 12px;
 }
 
-.authName {
-  font-size: 14px;
-  font-weight: 600;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .copyRow {
   display: flex;
   align-items: center;

--- a/src/components/escrow/escrow-token-panel.module.css
+++ b/src/components/escrow/escrow-token-panel.module.css
@@ -22,18 +22,6 @@
   }
 }
 
-.tokenHeader {
-  display: flex;
-  align-items: center;
-}
-
-.tokenSymbol {
-  display: block;
-  font-size: 22px;
-  font-weight: 700;
-  line-height: 1.1;
-}
-
 .overline {
   display: block;
   font-size: 12px;
@@ -147,31 +135,40 @@
   gap: 10px;
 }
 
-.authSectionTitle {
-  font-size: 18px;
-  font-weight: 700;
-  line-height: 1.2;
-}
-
 .createAuthButton {
   margin-left: auto;
 }
 
 .authHeader {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   flex-wrap: wrap;
   justify-content: space-between;
   gap: 12px;
 }
 
-.authSpender {
+.authName {
   font-size: 14px;
   font-weight: 600;
-  font-variant-numeric: tabular-nums;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.copyRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0px 8px;
+  white-space: nowrap;
+  font-size: 13px;
+
+  .hash {
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .statsGrid {
@@ -356,11 +353,4 @@
 .noAuthTitle {
   font-size: 17px;
   font-weight: 700;
-}
-
-.noAuthDesc {
-  font-size: 14px;
-  color: var(--text-secondary);
-  max-width: 400px;
-  line-height: 1.5;
 }

--- a/src/components/escrow/escrow-token-panel.module.css
+++ b/src/components/escrow/escrow-token-panel.module.css
@@ -99,16 +99,23 @@
   gap: 10px;
 }
 
-.fundRow {
-  display: flex;
-}
-
 .fundInput {
-  flex: 1;
+  width: 100%;
   min-width: 0;
 }
 
+.fundButtons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  @media (min-width: 576px) {
+    flex-direction: row;
+  }
+}
+
 .fundButton {
+  flex: 1;
   white-space: nowrap;
 }
 

--- a/src/components/escrow/escrow-token-panel.tsx
+++ b/src/components/escrow/escrow-token-panel.tsx
@@ -1,4 +1,5 @@
 import Button from '@/components/button/button';
+import CopyButton from '@/components/button/copy-button';
 import Card from '@/components/card/card';
 import CreateAuthorizationModal from '@/components/escrow/create-authorization-modal';
 import EditAuthorizationModal from '@/components/escrow/edit-authorization-modal';
@@ -64,8 +65,34 @@ const AuthorizationCard = ({
     <Card direction="column" innerShadow="black" padding="sm" radius="md" spacing="sm" variant="glass">
       {/* Auth header */}
       <div className={styles.authHeader}>
-        <div className={styles.authSpender} title={spender.spender}>
-          Consumer {formatWalletAddress(spender.spender)}
+        <div>
+          <h4>{spender.nodeFriendlyName ?? (spender.nodeId ? 'Unnamed node' : 'Unknown node')}</h4>
+          {spender.nodeId && (
+            <div className={styles.copyRow}>
+              <strong>Peer ID:</strong>
+              <span className={styles.hash}>{formatWalletAddress(spender.nodeId)}</span>
+              <CopyButton
+                color="accent1"
+                contentToCopy={spender.nodeId}
+                label=""
+                labelCopied=""
+                size="sm"
+                variant="transparent"
+              />
+            </div>
+          )}
+          <div className={styles.copyRow}>
+            <strong>ETH Address:</strong>
+            <span className={styles.hash}>{formatWalletAddress(spender.spender)}</span>
+            <CopyButton
+              color="accent1"
+              contentToCopy={spender.spender}
+              label=""
+              labelCopied=""
+              size="sm"
+              variant="transparent"
+            />
+          </div>
         </div>
         <IconButton
           aria-label="Authorization actions"
@@ -130,7 +157,7 @@ const AuthorizationCard = ({
           <span className={styles.statValue}>{formatDuration(Number(auth.maxLockSeconds), true)}</span>
         </div>
         <div className={styles.statField}>
-          <span className={styles.statLabel}>Locks used</span>
+          <span className={styles.statLabel}>Locks used (Active jobs)</span>
           <div className={styles.locksUsedRow}>
             <span className={styles.statValue}>
               {locksUsed} / {locksMax}
@@ -156,7 +183,7 @@ const AuthorizationCard = ({
             type="button"
           >
             <ChevronRightIcon className={locksOpen ? styles.chevronOpen : styles.chevron} fontSize="small" />
-            <span className={styles.overline}>Active Locks</span>
+            <span className={styles.overline}>Active jobs</span>
           </button>
           <Collapse in={locksOpen} timeout="auto" unmountOnExit>
             <div className={styles.locksTable}>
@@ -243,10 +270,7 @@ const EscrowTokenPanel = ({ token, spenders, loadingSpenders, onChange }: Escrow
       <div className={styles.panel}>
         {/* ── Left: balance + move funds ── */}
         <div className={styles.left}>
-          {/* Token header */}
-          <div className={styles.tokenHeader}>
-            <span className={styles.tokenSymbol}>{token.symbol}</span>
-          </div>
+          <h3>{token.symbol}</h3>
 
           {/* Primary balance */}
           <div className={styles.primaryBalance}>
@@ -260,7 +284,7 @@ const EscrowTokenPanel = ({ token, spenders, loadingSpenders, onChange }: Escrow
           {/* Secondary balances */}
           <div className={styles.secondaryBalances}>
             <div className={styles.secondaryRow}>
-              <span className={styles.secondaryLabel}>Locked in escrow</span>
+              <span className={styles.secondaryLabel}>Locked for running jobs</span>
               <span className={styles.secondaryAmount}>
                 <strong>{formatTokenAmount(token.locked, token.address)}</strong>{' '}
                 <span className={styles.secondarySymbol}>{token.symbol}</span>
@@ -342,10 +366,10 @@ const EscrowTokenPanel = ({ token, spenders, loadingSpenders, onChange }: Escrow
         {/* ── Right: authorizations & locks (one card per authorized spender) ── */}
         <div className={styles.right}>
           <div className={styles.authSectionHeader}>
-            <span className={styles.authSectionTitle}>Authorizations</span>
+            <h3>Authorizations</h3>
             {spenders.length > 0 && (
               <span className="chip chipGlass">
-                {spenders.length} {spenders.length === 1 ? 'consumer' : 'consumers'}
+                {spenders.length} {spenders.length === 1 ? 'node' : 'nodes'}
               </span>
             )}
             <Button
@@ -373,9 +397,6 @@ const EscrowTokenPanel = ({ token, spenders, loadingSpenders, onChange }: Escrow
                 <LockOutlinedIcon sx={{ fontSize: 28 }} />
               </div>
               <span className={styles.noAuthTitle}>No authorization yet</span>
-              <span className={styles.noAuthDesc}>
-                An authorization is created automatically the first time you pay for a compute job with {token.symbol}.
-              </span>
             </div>
           )}
         </div>

--- a/src/components/escrow/escrow-token-panel.tsx
+++ b/src/components/escrow/escrow-token-panel.tsx
@@ -320,6 +320,7 @@ const EscrowTokenPanel = ({ token, spenders, loadingSpenders, onChange }: Escrow
                 setAmount(e.target.value);
                 setError(undefined);
               }}
+              placeholder="Amount"
               size="md"
               startAdornment={token.symbol}
               type="number"

--- a/src/components/escrow/escrow-token-panel.tsx
+++ b/src/components/escrow/escrow-token-panel.tsx
@@ -20,9 +20,7 @@ import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import { CircularProgress, Collapse, IconButton, ListItemIcon, MenuItem } from '@mui/material';
 import classNames from 'classnames';
-import { useFormik } from 'formik';
 import { useRef, useState } from 'react';
-import * as Yup from 'yup';
 import styles from './escrow-token-panel.module.css';
 
 type EscrowTokenPanelProps = {
@@ -30,10 +28,6 @@ type EscrowTokenPanelProps = {
   spenders: EscrowSpenderInfo[];
   loadingSpenders: boolean;
   onChange: () => void;
-};
-
-type AmountFormValues = {
-  amount: number | '';
 };
 
 // One spending-authorization card (right-hand side). A token can have multiple authorized
@@ -234,36 +228,52 @@ const AuthorizationCard = ({
 const EscrowTokenPanel = ({ token, spenders, loadingSpenders, onChange }: EscrowTokenPanelProps) => {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
 
+  // Single amount input drives both actions. amount > 0 is the base check; the per-action
+  // balance ceiling (wallet for deposit, escrow for withdraw) is validated at click time
+  // since it depends on which button was pressed.
+  const [amount, setAmount] = useState('');
+  const [error, setError] = useState<string | undefined>();
+
   const { handleDeposit, isDepositing } = useDepositTokens({
     onSuccess: () => {
-      depositForm.resetForm();
+      setAmount('');
       onChange();
     },
   });
   const { handleWithdraw, isWithdrawing } = useWithdrawTokens({
     onSuccess: () => {
-      withdrawForm.resetForm();
+      setAmount('');
       onChange();
     },
   });
 
-  const depositForm = useFormik<AmountFormValues>({
-    initialValues: { amount: '' },
-    onSubmit: (values) => handleDeposit({ tokenAddress: token.address, amount: values.amount.toString() }),
-    validateOnMount: true,
-    validationSchema: Yup.object({
-      amount: Yup.number().moreThan(0, 'Invalid amount').max(token.walletBalance, 'Exceeds wallet balance'),
-    }),
-  });
+  const onDeposit = () => {
+    const value = Number(amount);
+    if (!(value > 0)) {
+      setError('Invalid amount');
+      return;
+    }
+    if (value > token.walletBalance) {
+      setError('Exceeds wallet balance');
+      return;
+    }
+    setError(undefined);
+    handleDeposit({ tokenAddress: token.address, amount: value.toString() });
+  };
 
-  const withdrawForm = useFormik<AmountFormValues>({
-    initialValues: { amount: '' },
-    onSubmit: (values) => handleWithdraw({ tokenAddresses: [token.address], amounts: [values.amount.toString()] }),
-    validateOnMount: true,
-    validationSchema: Yup.object({
-      amount: Yup.number().moreThan(0, 'Invalid amount').max(token.available, 'Exceeds available funds'),
-    }),
-  });
+  const onWithdraw = () => {
+    const value = Number(amount);
+    if (!(value > 0)) {
+      setError('Invalid amount');
+      return;
+    }
+    if (value > token.available) {
+      setError('Exceeds available funds');
+      return;
+    }
+    setError(undefined);
+    handleWithdraw({ tokenAddresses: [token.address], amounts: [value.toString()] });
+  };
 
   return (
     <Card direction="column" padding="md" radius="lg" shadow="black" spacing="md" variant="glass-shaded">
@@ -301,65 +311,48 @@ const EscrowTokenPanel = ({ token, spenders, loadingSpenders, onChange }: Escrow
 
           {/* Move funds */}
           <div className={styles.moveFunds}>
-            <span className={styles.overline}>Move funds</span>
-            <form className={styles.fundRow} onSubmit={depositForm.handleSubmit}>
-              <Input
-                className={styles.fundInput}
-                endAdornment={
-                  <Button
-                    className={styles.fundButton}
-                    color="accent1"
-                    contentBefore={<FileUploadOutlinedIcon fontSize="small" />}
-                    disabled={!depositForm.isValid || !depositForm.values.amount}
-                    loading={isDepositing}
-                    size="sm"
-                    type="submit"
-                    variant="filled"
-                  >
-                    Deposit
-                  </Button>
-                }
-                errorText={
-                  depositForm.touched.amount && depositForm.errors.amount ? depositForm.errors.amount : undefined
-                }
-                name="amount"
-                onBlur={depositForm.handleBlur}
-                onChange={depositForm.handleChange}
+            <Input
+              className={styles.fundInput}
+              errorText={error}
+              label="Move funds"
+              name="amount"
+              onChange={(e) => {
+                setAmount(e.target.value);
+                setError(undefined);
+              }}
+              size="md"
+              startAdornment={token.symbol}
+              type="number"
+              value={amount}
+            />
+            <div className={styles.fundButtons}>
+              <Button
+                className={styles.fundButton}
+                color="accent1"
+                contentBefore={<FileDownloadOutlinedIcon fontSize="small" />}
+                disabled={!amount || isDepositing || Number(amount) > token.available}
+                loading={isWithdrawing}
+                onClick={onWithdraw}
                 size="md"
-                startAdornment={token.symbol}
-                type="number"
-                value={depositForm.values.amount}
-              />
-            </form>
-            <form className={styles.fundRow} onSubmit={withdrawForm.handleSubmit}>
-              <Input
-                className={styles.fundInput}
-                endAdornment={
-                  <Button
-                    className={styles.fundButton}
-                    color="accent1"
-                    contentBefore={<FileDownloadOutlinedIcon fontSize="small" />}
-                    disabled={!withdrawForm.isValid || !withdrawForm.values.amount}
-                    loading={isWithdrawing}
-                    size="sm"
-                    type="submit"
-                    variant="outlined"
-                  >
-                    Withdraw
-                  </Button>
-                }
-                errorText={
-                  withdrawForm.touched.amount && withdrawForm.errors.amount ? withdrawForm.errors.amount : undefined
-                }
-                name="amount"
-                onBlur={withdrawForm.handleBlur}
-                onChange={withdrawForm.handleChange}
+                type="button"
+                variant="outlined"
+              >
+                Withdraw
+              </Button>
+              <Button
+                className={styles.fundButton}
+                color="accent1"
+                contentBefore={<FileUploadOutlinedIcon fontSize="small" />}
+                disabled={!amount || isWithdrawing || Number(amount) > token.walletBalance}
+                loading={isDepositing}
+                onClick={onDeposit}
                 size="md"
-                startAdornment={token.symbol}
-                type="number"
-                value={withdrawForm.values.amount}
-              />
-            </form>
+                type="button"
+                variant="filled"
+              >
+                Deposit
+              </Button>
+            </div>
           </div>
         </div>
 

--- a/src/components/escrow/escrow-token-panel.tsx
+++ b/src/components/escrow/escrow-token-panel.tsx
@@ -249,7 +249,7 @@ const EscrowTokenPanel = ({ token, spenders, loadingSpenders, onChange }: Escrow
 
   const onDeposit = () => {
     const value = Number(amount);
-    if (!(value > 0)) {
+    if (value <= 0) {
       setError('Invalid amount');
       return;
     }
@@ -263,7 +263,7 @@ const EscrowTokenPanel = ({ token, spenders, loadingSpenders, onChange }: Escrow
 
   const onWithdraw = () => {
     const value = Number(amount);
-    if (!(value > 0)) {
+    if (value <= 0) {
       setError('Invalid amount');
       return;
     }

--- a/src/lib/use-escrow-data.ts
+++ b/src/lib/use-escrow-data.ts
@@ -1,6 +1,9 @@
 import { useOceanAccount } from '@/lib/use-ocean-account';
+import { getApiRoute } from '@/config';
 import { getSupportedTokens } from '@/constants/tokens';
 import { Authorizations, EscrowLock } from '@/types/payment';
+import { Node } from '@/types/nodes';
+import axios from 'axios';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 
@@ -22,6 +25,29 @@ export type EscrowSpenderInfo = {
   spender: string;
   authorizations: Authorizations;
   locks: EscrowLock[];
+  // Resolved from the nodes API by matching the spender wallet to a node's `address`.
+  // Undefined while loading or if the wallet maps to no known node.
+  nodeId?: string;
+  nodeFriendlyName?: string;
+};
+
+// Look up the node whose payment wallet equals `wallet`, using the same filtered nodes
+// endpoint as the leaderboard. Returns id + friendly name, or null if none matches.
+const fetchNodeByWallet = async (wallet: string): Promise<{ id: string; friendlyName?: string } | null> => {
+  try {
+    const filters = { address: { operator: 'equals', value: wallet } };
+    const res = await axios.get(
+      `${getApiRoute('nodes')}?page=0&size=1&filters=${encodeURIComponent(JSON.stringify(filters))}`
+    );
+    const node: Node | undefined = res.data?.nodes?.[0]?._source;
+    if (!node?.id) {
+      return null;
+    }
+    return { id: node.id, friendlyName: node.friendlyName };
+  } catch (err) {
+    console.error(`Failed to resolve node for wallet ${wallet}:`, err);
+    return null;
+  }
 };
 
 export type UseEscrowDataReturn = {
@@ -102,6 +128,22 @@ export const useEscrowData = (): UseEscrowDataReturn => {
         // Drop revoked authorizations — limits all zeroed, no longer usable.
         .filter((info) => !isRevokedAuthorization(info.authorizations) || info.locks.length > 0);
       setSpenders(spenderInfos);
+
+      // Enrich each spender with its node id. One lookup per unique wallet (a wallet can
+      // appear across multiple tokens), then map results back onto every matching spender.
+      const uniqueWallets = [...new Set(spenderInfos.map((info) => info.spender))];
+      const nodeByWallet = new Map<string, { id: string; friendlyName?: string } | null>();
+      await Promise.all(
+        uniqueWallets.map(async (wallet) => {
+          nodeByWallet.set(wallet, await fetchNodeByWallet(wallet));
+        })
+      );
+      setSpenders((current) =>
+        current.map((info) => {
+          const node = nodeByWallet.get(info.spender);
+          return node ? { ...info, nodeId: node.id, nodeFriendlyName: node.friendlyName } : info;
+        })
+      );
     } catch (err) {
       console.error('Failed to load escrow data:', err);
     } finally {

--- a/src/lib/use-escrow-data.ts
+++ b/src/lib/use-escrow-data.ts
@@ -43,9 +43,19 @@ const fetchNodesByWallets = async (
     return byWallet;
   }
   try {
-    const filters = { address: { value: wallets.join(','), operator: 'terms' } };
     const res = await axios.get(
-      `${getApiRoute('nodes')}?page=0&size=${wallets.length}&filters=${encodeURIComponent(JSON.stringify(filters))}`
+      getApiRoute('nodes'), {
+      params: {
+        page: 0,
+        size: wallets.length,
+        filters: JSON.stringify({
+          address: {
+            value: wallets.join(','),
+            operator: 'terms'
+          }
+        }),
+      }
+    }
     );
     const nodes: { _source: Node }[] = res.data?.nodes ?? [];
     for (const { _source: node } of nodes) {

--- a/src/lib/use-escrow-data.ts
+++ b/src/lib/use-escrow-data.ts
@@ -31,23 +31,32 @@ export type EscrowSpenderInfo = {
   nodeFriendlyName?: string;
 };
 
-// Look up the node whose payment wallet equals `wallet`, using the same filtered nodes
-// endpoint as the leaderboard. Returns id + friendly name, or null if none matches.
-const fetchNodeByWallet = async (wallet: string): Promise<{ id: string; friendlyName?: string } | null> => {
-  try {
-    const filters = { address: { operator: 'equals', value: wallet } };
-    const res = await axios.get(
-      `${getApiRoute('nodes')}?page=0&size=1&filters=${encodeURIComponent(JSON.stringify(filters))}`
-    );
-    const node: Node | undefined = res.data?.nodes?.[0]?._source;
-    if (!node?.id) {
-      return null;
-    }
-    return { id: node.id, friendlyName: node.friendlyName };
-  } catch (err) {
-    console.error(`Failed to resolve node for wallet ${wallet}:`, err);
-    return null;
+// Resolve node ids for a list of payment wallets in a single request. The nodes endpoint
+// matches `address` against any value in a comma-separated list (backend splits it into an
+// OR of case-insensitive matches). Returns a map keyed by lowercased wallet address;
+// wallets with no matching node are simply absent.
+const fetchNodesByWallets = async (
+  wallets: string[]
+): Promise<Map<string, { id: string; friendlyName?: string }>> => {
+  const byWallet = new Map<string, { id: string; friendlyName?: string }>();
+  if (wallets.length === 0) {
+    return byWallet;
   }
+  try {
+    const filters = { address: { value: wallets.join(',') } };
+    const res = await axios.get(
+      `${getApiRoute('nodes')}?page=0&size=${wallets.length}&filters=${encodeURIComponent(JSON.stringify(filters))}`
+    );
+    const nodes: { _source: Node }[] = res.data?.nodes ?? [];
+    for (const { _source: node } of nodes) {
+      if (node?.id && node.address) {
+        byWallet.set(node.address.toLowerCase(), { id: node.id, friendlyName: node.friendlyName });
+      }
+    }
+  } catch (err) {
+    console.error('Failed to resolve nodes for wallets:', err);
+  }
+  return byWallet;
 };
 
 export type UseEscrowDataReturn = {
@@ -129,18 +138,14 @@ export const useEscrowData = (): UseEscrowDataReturn => {
         .filter((info) => !isRevokedAuthorization(info.authorizations) || info.locks.length > 0);
       setSpenders(spenderInfos);
 
-      // Enrich each spender with its node id. One lookup per unique wallet (a wallet can
-      // appear across multiple tokens), then map results back onto every matching spender.
+      // Enrich each spender with its node id. Collect the unique wallets (a wallet can
+      // appear across multiple tokens) and resolve them all in a single request, then map
+      // results back onto every matching spender.
       const uniqueWallets = [...new Set(spenderInfos.map((info) => info.spender))];
-      const nodeByWallet = new Map<string, { id: string; friendlyName?: string } | null>();
-      await Promise.all(
-        uniqueWallets.map(async (wallet) => {
-          nodeByWallet.set(wallet, await fetchNodeByWallet(wallet));
-        })
-      );
+      const nodeByWallet = await fetchNodesByWallets(uniqueWallets);
       setSpenders((current) =>
         current.map((info) => {
-          const node = nodeByWallet.get(info.spender);
+          const node = nodeByWallet.get(info.spender.toLowerCase());
           return node ? { ...info, nodeId: node.id, nodeFriendlyName: node.friendlyName } : info;
         })
       );

--- a/src/lib/use-escrow-data.ts
+++ b/src/lib/use-escrow-data.ts
@@ -43,7 +43,7 @@ const fetchNodesByWallets = async (
     return byWallet;
   }
   try {
-    const filters = { address: { value: wallets.join(',') } };
+    const filters = { address: { value: wallets.join(','), operator: 'terms' } };
     const res = await axios.get(
       `${getApiRoute('nodes')}?page=0&size=${wallets.length}&filters=${encodeURIComponent(JSON.stringify(filters))}`
     );

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -22,6 +22,7 @@ export type NodeBanInfo = {
 };
 
 export type Node = {
+  address?: string;
   allowedAdmins?: string[];
   banned: boolean;
   bannedAt?: number;


### PR DESCRIPTION
Fixes #553.

Merge https://github.com/oceanprotocol/incentive-backend/pull/166 first

Changes proposed in this PR:

- 
- 
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show node identity (peer ID and node-friendly name) in escrow/authorization headers with copy-to-clipboard for peer and ETH addresses.
  * Enrich escrow spender info with node ID/name when available.
* **UI Improvements**
  * Updated job-related wording (“Active jobs”, “Max concurrent jobs”, “Locked for running jobs”) and applied tighter small input sizing.
  * Redesigned “Move funds” to use unified validation/state and improved layout spacing/empty-state messaging.
* **Bug Fixes**
  * Improved node-consumer resolution logic when creating authorizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->