### PR TITLE
Add Claude Code .md and shared hooks/agents wiring

### DIFF
--- a/.claude/HOOKS.md
+++ b/.claude/HOOKS.md
@@ -1,0 +1,77 @@
+# Claude Code Hooks — nodes-dashboard
+
+This repo was the pilot for three Claude Code hooks (format+lint, destructive-command
+guard, PostCompact context refresh). After validating them here, they were extracted
+into the shared [ai-instructions](https://github.com/oceanprotocol/ai-instructions)
+repo so every Ocean repo pulls the same scripts instead of drifting local copies.
+
+**Source of truth for what each hook does:** [ai-instructions/hooks/README.md](../ai-instructions/hooks/README.md).
+This file only covers how nodes-dashboard is wired up and what's specific to this repo.
+
+## How this repo consumes the hooks
+
+- `ai-instructions` is a git submodule at [`./ai-instructions`](../ai-instructions).
+- [`.claude/hooks`](hooks) is a symlink to `../ai-instructions/hooks` — no
+  scripts are duplicated in this repo, so updates to the shared hooks only
+  require bumping the submodule pointer.
+- [`.claude/settings.json`](settings.json) wires the three hooks up; its content
+  is identical to [ai-instructions/hooks/settings.snippet.json](../ai-instructions/hooks/settings.snippet.json).
+
+```
+.claude/
+├── hooks -> ../ai-instructions/hooks   (symlink)
+├── settings.json                       (hooks config, matches the shared snippet)
+└── HOOKS.md                            (this file)
+ai-instructions/                        (git submodule)
+└── hooks/
+    ├── format-and-lint.sh
+    ├── block-destructive.sh
+    ├── refresh-context.sh
+    └── README.md
+```
+
+Pulling in future hook changes is a normal submodule bump:
+
+```bash
+git submodule update --remote ai-instructions
+git add ai-instructions
+git commit -m "Bump ai-instructions submodule"
+```
+
+After any hooks change lands, open `/hooks` once in your Claude Code session
+(or restart) so the update is picked up.
+
+## Validation already done (2026-07-21)
+
+All three scripts were pipe-tested with synthesized hook payloads directly
+against this repo's own toolchain (Yarn 4 node-modules linker, `.nvmrc` pinned
+to Node 24) — including force-push/`rm -rf` denials, the new `git commit`/
+`git push` confirmation prompts, and prettier/eslint actually reformatting a
+scratch `.ts` file. See `ai-instructions/hooks/README.md` for the full test
+notes from when these were generalized. Re-run anytime with:
+
+```bash
+export CLAUDE_PROJECT_DIR="$(pwd)"
+echo '{"tool_name":"Bash","tool_input":{"command":"git push --force"}}' | .claude/hooks/block-destructive.sh
+echo '{"tool_name":"Edit","tool_input":{"file_path":"'"$CLAUDE_PROJECT_DIR"'/src/some/file.ts"}}' | .claude/hooks/format-and-lint.sh
+echo '{"session_id":"test","trigger":"auto"}' | .claude/hooks/refresh-context.sh
+```
+
+Known repo quirk found during the pilot (unrelated to the hooks themselves):
+`.eslintrc.json` (extends only `next/core-web-vitals`) takes priority over
+`.eslintrc`, so the stricter rules in `.eslintrc` (`require-await`,
+`no-unused-vars`, …) are currently inactive — worth consolidating the two
+configs at some point.
+
+## Rollout decision (proposed, documented in full in ai-instructions/hooks/README.md)
+
+| Hook | Verdict | Where |
+|------|---------|-------|
+| Block destructive commands | Roll out broadly | All repos — repo-agnostic, zero deps beyond `jq` |
+| Format + lint after edits | Roll out per repo | Repos with prettier/eslint set up |
+| Refresh context after compaction | Roll out broadly | All repos — most valuable in repos that have a `CLAUDE.md` |
+
+Rollout: one PR per repo, following the "Wire up Claude Code hooks" steps in
+[ai-instructions/README.md](../ai-instructions/README.md#wire-up-claude-code-hooks),
+starting with the actively developed repos (ocean-node, ocean-cli, oceanJS,
+ocean-market, nodes-analytics, incentive-backend).

--- a/.claude/agents
+++ b/.claude/agents
@@ -1,0 +1,1 @@
+../ai-instructions/agents

--- a/.claude/hooks
+++ b/.claude/hooks
@@ -1,0 +1,1 @@
+../ai-instructions/hooks

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,42 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-destructive.sh",
+            "timeout": 10,
+            "statusMessage": "Checking command safety..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-and-lint.sh",
+            "timeout": 90,
+            "statusMessage": "Formatting & linting..."
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/refresh-context.sh",
+            "timeout": 15,
+            "statusMessage": "Refreshing project context..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ai-instructions"]
 	path = ai-instructions
 	url = https://github.com/oceanprotocol/ai-instructions.git
-    branch = feature/add-hooks
+	branch = feature/add-hooks

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "ai-instructions"]
 	path = ai-instructions
 	url = https://github.com/oceanprotocol/ai-instructions.git
-	branch = feature/add-hooks

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ai-instructions"]
 	path = ai-instructions
 	url = https://github.com/oceanprotocol/ai-instructions.git
-    branch = feature/ai-instructions
+    branch = feature/add-hooks

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "ai-instructions"]
+	path = ai-instructions
+	url = https://github.com/oceanprotocol/ai-instructions.git
+    branch = feature/ai-instructions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`nodes-dashboard` — the Next.js dashboard for Ocean Protocol node incentives and monitoring. It shows node maps, stats, and leaderboards, and hosts wallet-connected flows: running compute jobs, running/configuring your own node, profile/escrow management, token grants, and swapping tokens.
+
+## Stack at a glance
+
+- **Next.js 16**, Pages Router (`src/pages`, no `src/app`), React 18, TypeScript.
+- **Yarn 4** (Berry, `node-modules` linker) — use `yarn`, not `npm`. Node version is pinned by `.nvmrc` (see gotchas — don't trust the README or CI on this).
+- **UI**: MUI v7 + Emotion are dependencies, but most components actually style via co-located CSS Modules (`*.module.css`), not MUI's `sx` prop.
+- **Server state**: TanStack Query, one `QueryClient` created via `useRef` in `src/pages/_app.tsx`.
+- **Domain state**: ~15 React Context providers nested in `_app.tsx` (nodes, stats, profile, grant, run-job, run-node, P2P, node-auth, node-storage, etc.) rather than Redux/Zustand. Order in the provider tree matters — several inner providers depend on `useOceanAccount()`, which depends on Privy, so don't reorder casually.
+- **Wallet stack**, layered — use `src/lib/use-ocean-account.tsx`'s `useOceanAccount()` for "current wallet" state, not a lower-level library directly: Privy (`@privy-io/react-auth`) handles login/auth → `@privy-io/alchemy-migration` bridges to an Alchemy smart-contract account → `useOceanAccount()` branches between an `SCAHandler` (smart-account path) and an `EOAHandler` (plain wallet path, e.g. MetaMask).
+- **Direct Ocean Node calls** (bypassing the incentive-backend proxy) go through `@oceanprotocol/lib`'s `ProviderInstance` in `src/services/nodeService.ts`.
+- **Charts**: `recharts`, in `src/components/chart/`.
+
+## Commands
+
+```bash
+yarn dev         # next dev
+yarn build       # next build --webpack (NODE_OPTIONS max-old-space-size=4096, see gotchas)
+yarn start       # next start
+yarn lint        # eslint --ext .ts,.tsx .
+yarn lint:fix
+yarn format      # prettier --write
+```
+
+**There is no test script and no automated test suite.** CI (`.github/workflows/ci.yml`) only runs `yarn lint` — a green CI run does not mean the app builds or works.
+
+## Architecture, briefly
+
+- `src/pages/` — routes, plus API routes under `src/pages/api/` (`rpc.ts`, and the server-side Grant flow under `api/grant/*`).
+- `src/context/` and `src/contexts/` — domain state providers (note the split across two similarly-named folders; both are wired into `_app.tsx`).
+- `src/lib/` — wallet/web3 hooks and adapters (see stack section above), plus the query client.
+- `src/services/` and `src/api-services/` — backend integration. `src/config.ts` defines `API_ROOTS`/`apiRoutes`, switching between dev/prod URLs for the incentive-backend and analytics services based on `NEXT_PUBLIC_APP_ENV`. `src/api-services/*` backs the server-only Grant flow (Google Sheets, Gmail, Gemini).
+- `src/components/` — ~35 feature folders. Filenames are kebab-case (`pie-chart.tsx`), exported components are PascalCase. Styling is co-located CSS Modules per component.
+
+## Environment
+
+Env vars live in `.env`/`.env.local` (never commit real values). Notable ones: `NEXT_PUBLIC_APP_ENV` (dev vs prod — picks backend URLs and chain: Sepolia vs Base), Alchemy/Privy keys (`NEXT_PUBLIC_ALCHEMY_API_KEY`, `NEXT_PUBLIC_ALCHEMY_POLICY_ID`, `NEXT_PUBLIC_PRIVY_APP_ID`), Grant-flow server secrets (`GEMINI_API_KEY`, `GRANT_GSHEETS_*`, `GRANT_GMAIL_*`, `GRANT_FAUCET_PRIVATE_KEY`), `NEXT_PUBLIC_GPU_LIST`.
+
+## Known gotchas
+
+- **`.eslintrc` vs `.eslintrc.json`**: ESLint's config precedence means `.eslintrc.json` (which only extends `next/core-web-vitals`) wins over `.eslintrc` (which adds `require-await: error`, `no-unused-vars: error`, etc.) — the stricter rules are currently inactive. Worth consolidating; don't assume those rules are enforced.
+- **Node version disagreement**: `.nvmrc` pins `v24.15.0`, but README and `ci.yml` both say `20.16.0`. Trust `.nvmrc`.
+- **Wagmi is not actually used**, despite being a dependency and mentioned in the README's stack table — there are no `from 'wagmi'` imports anywhere in `src/`. The real wallet abstraction is `src/lib/use-ocean-account.tsx`.
+- **`src/lib/config.ts` exports an unused second `QueryClient`** — the one actually wired into the app is created separately in `_app.tsx`. Likely dead code; don't build on the one in `lib/config.ts`.
+- **`src/lib/alchemy-provider.tsx` installs a "TEMP DIAGNOSTIC" fetch logger** (`installPrivyAlchemyFetchLogger()`) at module load — leftover debug instrumentation from a Privy/Alchemy migration, not something to extend.
+- `tsconfig.json` declares `@Types/*` → `src/shared/types/*` and `@utils/*` → `src/shared/utils/*`, but only `src/shared/consts/` actually exists — those two aliases don't currently resolve to anything.
+- Production builds require `NODE_OPTIONS=--max-old-space-size=4096` (already set in the `build` script) — the build is memory-constrained.
+
+## Verifying changes
+
+Since there's no automated test suite, this is the actual bar: run `yarn lint` and fix anything it flags, then run `yarn dev` and manually exercise the affected page or flow in a browser — including loading/empty/error states, and if the change touches wallet code, check it against both the SCA and EOA account paths where relevant. Don't report a change as working without having done this.
+
+## AI tooling
+
+This repo pulls shared Claude Code hooks and agents from the `ai-instructions` git submodule — see [`.claude/HOOKS.md`](.claude/HOOKS.md) for how that's wired up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-`nodes-dashboard` — the Next.js dashboard for Ocean Protocol node incentives and monitoring. It shows node maps, stats, and leaderboards, and hosts wallet-connected flows: running compute jobs, running/configuring your own node, profile/escrow management, token grants, and swapping tokens.
+`nodes-dashboard` — the Next.js dashboard for Ocean Network. It shows node stats, and leaderboards, and hosts wallet-connected flows: running compute jobs, running/configuring your own node, profile/escrow management, token grants, and swapping tokens.
 
 ## Stack at a glance
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- Adds `CLAUDE.md`: an orientation doc covering the stack 
- Adds `.claude/settings.json` + `.claude/HOOKS.md`, wiring up three Claude Code hooks (format+lint after edits, a guard on destructive Bash commands including `git commit`/`git push` confirmation, and a PostCompact context refresh) and the shared agent roster (`architect`, `frontend-developer`, `code-reviewer`, `security-check`, etc.) from the `ai-instructions` repo — `.claude/hooks` and `.claude/agents` are symlinks into it, matching the pattern already used in `oceanJS`.
- Adds `.gitmodules` registering `ai-instructions` as a submodule.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a repository guide for Claude Code, including the dashboard’s tech stack, environment expectations, known gotchas, and contributor verification steps.
  - Added repository-specific Claude hook documentation detailing the configured workflow and rollout approach.

- **Chores**
  - Added and configured shared Claude Code hook wiring via an `ai-instructions` submodule and linked hook/agent setup.
  - Updated safety checks and post-action automation (status messages, timeouts, and hook phases) for formatting/linting and context refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->