### PR TITLE
deploy sc on first interaction

### DIFF
--- a/src/lib/use-alchemy-client.ts
+++ b/src/lib/use-alchemy-client.ts
@@ -3,7 +3,7 @@ import { getEmbeddedWallet } from '@/lib/embedded-wallet';
 import { alchemyWalletTransport, createSmartWalletClient, type SmartWalletClient } from '@alchemy/wallet-apis';
 import { toViemAccount, useWallets } from '@privy-io/react-auth';
 import { useEffect, useMemo, useState } from 'react';
-import { createPublicClient, http, type LocalAccount } from 'viem';
+import { createPublicClient, http, zeroAddress, type LocalAccount } from 'viem';
 import { base, sepolia } from 'viem/chains';
 
 type Call = { to: `0x${string}`; data?: `0x${string}`; value?: bigint };
@@ -14,12 +14,14 @@ const chain = process.env.NEXT_PUBLIC_APP_ENV === 'production' ? base : sepolia;
 // deployed at it. Ocean Node verifies our signatures by calling isValidSignature on that address
 // (nonceHandler.isERC1271Valid), which can only fail while there is no code there — so a user who
 // has never transacted gets "consumer address and nonce signature mismatch" on every signed
-// command. Any UserOp carries the account's initCode, so a sponsored self-call with no data is the
-// cheapest way to materialise it.
+// command. Any UserOp carries the account's initCode, so a sponsored no-op call is the cheapest way
+// to materialise it. The no-op targets the zero address, NOT the account: Modular Account v2 rejects
+// execute(target == address(this)) inside validateUserOp (SelfCallRecursionDepthExceeded), which the
+// EntryPoint reports as "AA23 reverted".
 async function deployAccount(client: SmartWalletClient, account: `0x${string}`): Promise<void> {
   const code = await createPublicClient({ chain, transport: http(getRpc()) }).getCode({ address: account });
   if (code) return;
-  const { id } = await (client as any).sendCalls({ calls: [{ to: account, data: '0x' }], account });
+  const { id } = await (client as any).sendCalls({ calls: [{ to: zeroAddress, data: '0x' }], account });
   const result = await client.waitForCallsStatus({ id });
   if (result.status !== 'success') {
     throw new Error(`Could not activate your wallet (status: ${result.status}). Please try again.`);

--- a/src/lib/use-alchemy-client.ts
+++ b/src/lib/use-alchemy-client.ts
@@ -1,6 +1,8 @@
+import { getRpc } from '@/lib/constants';
 import { getEmbeddedWallet } from '@/lib/embedded-wallet';
 import { alchemyWalletTransport, createSmartWalletClient, type SmartWalletClient } from '@alchemy/wallet-apis';
 import { toViemAccount, useWallets } from '@privy-io/react-auth';
+import { ethers } from 'ethers';
 import { useEffect, useMemo, useState } from 'react';
 import type { LocalAccount } from 'viem';
 import { base, sepolia } from 'viem/chains';
@@ -8,6 +10,39 @@ import { base, sepolia } from 'viem/chains';
 type Call = { to: `0x${string}`; data?: `0x${string}`; value?: bigint };
 
 const chain = process.env.NEXT_PUBLIC_APP_ENV === 'production' ? base : sepolia;
+
+// A smart account is counterfactual until its first UserOp: the address is known but nothing is
+// deployed at it. Ocean Node verifies our signatures by calling isValidSignature on that address
+// (nonceHandler.isERC1271Valid), which can only fail while there is no code there — so a user who
+// has never transacted gets "consumer address and nonce signature mismatch" on every signed
+// command. Any UserOp carries the account's initCode, so a sponsored self-call with no data is the
+// cheapest way to materialise it.
+async function deployAccount(client: SmartWalletClient, account: `0x${string}`): Promise<void> {
+  const code = await new ethers.JsonRpcProvider(getRpc()).getCode(account);
+  if (code !== '0x') return;
+  const { id } = await (client as any).sendCalls({ calls: [{ to: account, data: '0x' }], account });
+  const result = await client.waitForCallsStatus({ id });
+  if (result.status !== 'success') {
+    throw new Error(`Could not activate your wallet (status: ${result.status}). Please try again.`);
+  }
+}
+
+// One deploy per account per session: concurrent signers await the same promise instead of each
+// spending a sponsored UserOp (the later ones would revert as "sender already constructed").
+// A failure is evicted so the next signature retries.
+const deployments = new Map<string, Promise<void>>();
+
+function ensureAccountDeployed(client: SmartWalletClient, account: `0x${string}`): Promise<void> {
+  let pending = deployments.get(account);
+  if (!pending) {
+    pending = deployAccount(client, account).catch((error) => {
+      deployments.delete(account);
+      throw error;
+    });
+    deployments.set(account, pending);
+  }
+  return pending;
+}
 
 function useAlchemyClient(): { client: SmartWalletClient | null; accountAddress?: `0x${string}` } {
   const { wallets } = useWallets();
@@ -83,6 +118,7 @@ export function useAlchemySendTransaction() {
   const signMessage = useMemo(() => {
     return async (message: string): Promise<string> => {
       if (!client || !accountAddress) throw new Error('Alchemy client not ready');
+      await ensureAccountDeployed(client, accountAddress);
       return await (client as any).signMessage({ message, account: accountAddress });
     };
   }, [client, accountAddress]);

--- a/src/lib/use-alchemy-client.ts
+++ b/src/lib/use-alchemy-client.ts
@@ -32,13 +32,14 @@ async function deployAccount(client: SmartWalletClient, account: `0x${string}`):
 const deployments = new Map<string, Promise<void>>();
 
 function ensureAccountDeployed(client: SmartWalletClient, account: `0x${string}`): Promise<void> {
-  let pending = deployments.get(account);
+  const key = account.toLowerCase();
+  let pending = deployments.get(key);
   if (!pending) {
     pending = deployAccount(client, account).catch((error) => {
-      deployments.delete(account);
+      deployments.delete(key);
       throw error;
     });
-    deployments.set(account, pending);
+    deployments.set(key, pending);
   }
   return pending;
 }

--- a/src/lib/use-alchemy-client.ts
+++ b/src/lib/use-alchemy-client.ts
@@ -2,9 +2,8 @@ import { getRpc } from '@/lib/constants';
 import { getEmbeddedWallet } from '@/lib/embedded-wallet';
 import { alchemyWalletTransport, createSmartWalletClient, type SmartWalletClient } from '@alchemy/wallet-apis';
 import { toViemAccount, useWallets } from '@privy-io/react-auth';
-import { ethers } from 'ethers';
 import { useEffect, useMemo, useState } from 'react';
-import type { LocalAccount } from 'viem';
+import { createPublicClient, http, type LocalAccount } from 'viem';
 import { base, sepolia } from 'viem/chains';
 
 type Call = { to: `0x${string}`; data?: `0x${string}`; value?: bigint };
@@ -18,8 +17,8 @@ const chain = process.env.NEXT_PUBLIC_APP_ENV === 'production' ? base : sepolia;
 // command. Any UserOp carries the account's initCode, so a sponsored self-call with no data is the
 // cheapest way to materialise it.
 async function deployAccount(client: SmartWalletClient, account: `0x${string}`): Promise<void> {
-  const code = await new ethers.JsonRpcProvider(getRpc()).getCode(account);
-  if (code !== '0x') return;
+  const code = await createPublicClient({ chain, transport: http(getRpc()) }).getCode({ address: account });
+  if (code) return;
   const { id } = await (client as any).sendCalls({ calls: [{ to: account, data: '0x' }], account });
   const result = await client.waitForCallsStatus({ id });
   if (result.status !== 'success') {

--- a/src/pages/api/rpc.ts
+++ b/src/pages/api/rpc.ts
@@ -3,6 +3,8 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 const ALLOWED_METHODS = new Set([
   'eth_call',
   'eth_getBalance',
+  // Tells a deployed smart account from a counterfactual one before signing.
+  'eth_getCode',
   'eth_chainId',
   'eth_blockNumber',
   'eth_estimateGas',


### PR DESCRIPTION
Changes proposed in this PR:

- If no tx is sent, smart contracts are not initialized, that means we are not able to generate an auth token. This PR sends an empty tx with gas sponsorship if no sc. account is deployed before generating an auth token
- 
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Smart accounts are automatically deployed on-chain when needed before signing transactions or messages.
  - Initial account deployment is sponsored, helping users get started without separately funding deployment costs.
  - Deployment requests are coordinated to prevent duplicate transactions during a session.

- **Bug Fixes**
  - Failed deployments can be retried automatically, improving recovery from temporary transaction issues.
  - Signing is more reliable for accounts that have not yet been deployed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->