### PR TITLE
keep selected resources when prolonging; fix gpu set to max when prol…

### DIFF
--- a/src/components/inference/manage-service-page.tsx
+++ b/src/components/inference/manage-service-page.tsx
@@ -496,7 +496,13 @@ const ManageServicePage: React.FC = () => {
   // expiry check: extend does `expiresAt += additionalDuration` with no past-expiry guard of its own,
   // so a service still reading Running while past expiresAt (expiry-cron lag) would charge the user
   // and land on a new expiresAt that is still in the past — paying for zero runtime.
-  const canProlong = !!job && !isExpired && !isProlongBlocked(job.status) && !!selectedToken;
+  // Prolong prices the extra runtime off the resources the service HOLDS, which only `bookedResources`
+  // (the node's own job record) can tell us when the page was opened from the services table — its
+  // Manage link carries no `gpus`/`res`, so the hydrated selection is empty and would expand to a
+  // whole-env slice at payment. Without a resource record there is nothing correct to price against,
+  // so hold the action rather than quote (and escrow) every free GPU in the env.
+  const canProlong =
+    !!job && !isExpired && !isProlongBlocked(job.status) && !!selectedToken && !!bookedResources;
   const baseUrl = serviceBaseUrl(job);
   const docsUrl = serviceDocsUrl(job, baseUrl);
   const primaryModelName = models[0]?.params?.servedModelName || models[0]?.model.id || 'model';

--- a/src/components/inference/payment-page.tsx
+++ b/src/components/inference/payment-page.tsx
@@ -17,6 +17,7 @@ import { useOceanAccount } from '@/lib/use-ocean-account';
 import { usePaySession } from '@/lib/use-pay-session';
 import { computeEscrowRequirement, usePaymentInfo } from '@/lib/use-payment-info';
 import { buildInferenceRestartSpec, buildInferenceStartParams, toNodeUri } from '@/services/inference-launch';
+import { decodeGpuSelection, decodeResourceSizing } from '@/services/inference-url';
 import {
   buildTemplateRestartParams,
   buildTemplateStartParams,
@@ -77,18 +78,38 @@ const PaymentPage: React.FC<{ flowType: InferenceFlowType }> = ({ flowType }) =>
   // Computed once — reused by the prev-step routing and the stepper below.
   const needsConfigStep = templateNeedsConfigStep(selectedTemplate);
 
+  /**
+   * The allocation to price, URL first. The Provider mounts once and never remounts, so context's
+   * `selectedEnv` is only rewritten when the hydration signature (models/peerId/env/serviceId/template)
+   * changes — `gpus`/`res` are deliberately NOT in it. An edit/prolong re-entry changes only those two
+   * (the manage page puts the running service's BOOKED resources on the query, see selectionOverrides),
+   * so reading context here would price a prolong off whatever the manage page was hydrated with —
+   * `{}` when it was opened from the services table, which useInferenceAllocation reads as "no explicit
+   * request" and expands to a whole-env slice: every free GPU in the env, silently escrowed.
+   * The query is the fresher of the two whenever it carries a selection; context covers in-flow steps
+   * (resources → payment) that navigate without one.
+   */
+  const gpuSelection = useMemo(
+    () => decodeGpuSelection(router.query.gpus) ?? selectedEnv?.gpuSelection,
+    [router.query.gpus, selectedEnv?.gpuSelection]
+  );
+  const sizing = useMemo(
+    () => decodeResourceSizing(router.query.res) ?? selectedEnv?.sizing,
+    [router.query.res, selectedEnv?.sizing]
+  );
+
   // Same CPU/RAM/disk allocation shown in the payment summary — reused to size the launch request,
   // and the same price — reused to size the escrow deposit/authorization before launching.
   // Safe fallbacks keep the hook unconditional; real values only matter once selectedEnv/token exist.
   const { allocation, price, selectedByKey } = useInferenceAllocation({
     environment: selectedEnv?.environment ?? ({ resources: [] } as any),
     tokenAddress: selectedToken?.address ?? '',
-    gpuSelection: selectedEnv?.gpuSelection,
+    gpuSelection,
     // Quick start pins the package's recommended CPU/RAM/disk; the advanced handoff floors the fraction
     // slice at the package min; an edit/prolong re-entry carries the running service's `exact` booked
     // amounts (see parseServiceResources); undefined for a plain custom-flow slice. Keeps the
     // priced/escrowed allocation matching what the resources step — or the running service — showed.
-    sizing: selectedEnv?.sizing,
+    sizing,
     durationSeconds: jobDurationSeconds,
   });
 
@@ -734,8 +755,8 @@ const PaymentPage: React.FC<{ flowType: InferenceFlowType }> = ({ flowType }) =>
                     defaultToken={selectedToken?.address}
                     durationSeconds={jobDurationSeconds}
                     environment={selectedEnv.environment}
-                    gpuSelection={selectedEnv.gpuSelection}
-                    sizing={selectedEnv.sizing}
+                    gpuSelection={gpuSelection}
+                    sizing={sizing}
                     nodeInfo={selectedEnv.nodeInfo}
                   />
                 </>


### PR DESCRIPTION
Fixes #590 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service extensions are now blocked when resource allocation details are unavailable, preventing incorrect pricing or payment.
  * Payment and launch flows now consistently use the selected GPU and resource quantities from the current request.
  * Fixed issues where outdated or missing selections could result in incorrect prices, payment summaries, launch quantities, or displayed environment settings during service edits and extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->