### PR TITLE
Warn users before a paid session expires

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -61,6 +61,16 @@ const nextConfig = {
     ];
     return config;
   },
+  async headers() {
+    return [
+      {
+        // The browser only picks up a new worker if it can actually re-fetch this file; a cached
+        // copy pins whatever shipped first. Everything else in /public may cache normally.
+        source: '/sw.js',
+        headers: [{ key: 'Cache-Control', value: 'no-cache, no-store, must-revalidate' }],
+      },
+    ];
+  },
   env: {
     INCENTIVE_BACKEND_URL: process.env.INCENTIVE_BACKEND_URL,
   },

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,57 @@
+/**
+ * Session-expiry notifications worker.
+ *
+ * Deliberately minimal, and deliberately WITHOUT a `fetch` handler. A worker that cannot intercept
+ * requests cannot serve a stale bundle, so the usual way a service worker bricks a deploy is
+ * designed out rather than guarded against. Do not add caching here — this file exists only to own
+ * notification clicks (and, later, push events).
+ *
+ * Served from /public, so it lands at /sw.js and gets root scope for free.
+ */
+
+self.addEventListener('install', () => {
+  // No caches to warm, so there is nothing to wait for — take over immediately rather than sitting
+  // in `waiting` until every tab closes.
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const target = (event.notification.data && event.notification.data.url) || '/inference';
+
+  event.waitUntil(
+    (async () => {
+      const windows = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+      const existing = windows.find((client) => {
+        try {
+          return new URL(client.url).origin === self.location.origin;
+        } catch {
+          return false;
+        }
+      });
+
+      // Reuse the dashboard tab if one is open, so clicking a warning doesn't pile up duplicates.
+      if (existing) {
+        // `navigate` only works on clients this worker controls. A tab loaded before the worker
+        // activated is uncontrolled and throws, so fall through to focusing it as-is.
+        if ('navigate' in existing) {
+          try {
+            const navigated = await existing.navigate(target);
+            if (navigated) {
+              return navigated.focus();
+            }
+          } catch {
+            // uncontrolled client — focus without navigating
+          }
+        }
+        return existing.focus();
+      }
+
+      return self.clients.openWindow(target);
+    })()
+  );
+});

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,5 +1,6 @@
 import DocsWidget from '@/components/docs/docs-widget';
 import FooterSection from '@/components/homepage/footer-section';
+import SessionExpiryNotifier from '@/components/inference/session-expiry-notifier';
 import Navigation from '@/components/Navigation/navigation';
 import Head from 'next/head';
 import { ReactNode } from 'react';
@@ -19,6 +20,8 @@ export default function RootLayout({ children }: RootLayoutProps) {
       </Head>
       <div className={styles.main}>
         <Navigation />
+        {/* App-wide, so a session's expiry warning follows the user off the manage page. */}
+        <SessionExpiryNotifier />
         {children}
         <FooterSection />
         <DocsWidget />

--- a/src/components/inference/manage-service-page.tsx
+++ b/src/components/inference/manage-service-page.tsx
@@ -9,6 +9,7 @@ import InferenceModelList, { ServiceModel } from '@/components/inference/inferen
 import ProlongSessionModal from '@/components/inference/prolong-session-modal';
 import ProvisioningProgress from '@/components/inference/provisioning-progress';
 import ServiceLogsPanel from '@/components/inference/service-logs-panel';
+import SessionAlertsToggle from '@/components/inference/session-alerts-toggle';
 import TemplateSummary from '@/components/inference/template-summary';
 import ProgressBar from '@/components/progress-bar/progress-bar';
 import SectionTitle from '@/components/section-title/section-title';
@@ -28,9 +29,10 @@ import {
 } from '@/services/inference-launch';
 import { firstQueryValue } from '@/services/inference-url';
 import { getServiceStatusView, isProlongBlocked, isRestartBlocked } from '@/services/service-status';
+import { rememberSession } from '@/services/session-expiry';
 import { deepLinkWorkflow, templateOpenUrl, templatePrimaryPort } from '@/services/template-launch';
 import { isBundle } from '@/types/templates';
-import { formatDuration } from '@/utils/formatters';
+import { formatDuration, formatHMS } from '@/utils/formatters';
 import BoltOutlinedIcon from '@mui/icons-material/BoltOutlined';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
@@ -97,18 +99,6 @@ const TERMINAL_STATUSES = new Set<ServiceStatusNumber>([
   ServiceStatusNumber.Expired,
   ServiceStatusNumber.Error,
 ]);
-
-function pad(value: number): string {
-  return String(value).padStart(2, '0');
-}
-
-function formatHMS(totalSeconds: number): string {
-  const sec = Math.max(0, Math.floor(totalSeconds));
-  const h = Math.floor(sec / 3600);
-  const m = Math.floor((sec % 3600) / 60);
-  const s = sec % 60;
-  return `${pad(h)}:${pad(m)}:${pad(s)}`;
-}
 
 /** Live time-running progress bar with a ticking countdown to session end. */
 const DurationProgress: React.FC<{ totalSeconds: number; elapsedSeconds: number; onExpired?: () => void }> = ({
@@ -501,8 +491,7 @@ const ManageServicePage: React.FC = () => {
   // Manage link carries no `gpus`/`res`, so the hydrated selection is empty and would expand to a
   // whole-env slice at payment. Without a resource record there is nothing correct to price against,
   // so hold the action rather than quote (and escrow) every free GPU in the env.
-  const canProlong =
-    !!job && !isExpired && !isProlongBlocked(job.status) && !!selectedToken && !!bookedResources;
+  const canProlong = !!job && !isExpired && !isProlongBlocked(job.status) && !!selectedToken && !!bookedResources;
   const baseUrl = serviceBaseUrl(job);
   const docsUrl = serviceDocsUrl(job, baseUrl);
   const primaryModelName = models[0]?.params?.servedModelName || models[0]?.model.id || 'model';
@@ -536,6 +525,45 @@ const ManageServicePage: React.FC = () => {
   const onLocalExpiry = useCallback(() => {
     setPollEpoch((epoch) => epoch + 1);
   }, []);
+
+  // Record the node's authoritative expiry so the app-wide notifier can warn about this session from
+  // any page (and after a reload, or in another tab). Deliberately its own effect rather than a line
+  // inside fetchStatus: the fields it reads (serviceName, asPath) would join fetchStatus's dep list,
+  // and fetchStatus is a dep of the poll effect — the 4s loop would re-arm on every rename. Depends
+  // on the job's primitives, not the object, so a poll that changed nothing doesn't rewrite the store.
+  const jobServiceId = job?.serviceId;
+  const jobExpiresAt = job?.expiresAt;
+  const jobStatus = job?.status;
+  const jobDateCreated = job?.dateCreated;
+  useEffect(() => {
+    if (!jobServiceId || !jobExpiresAt || !account.address) {
+      return;
+    }
+    const startedAt = new Date(jobDateCreated ?? '').getTime();
+    if (!Number.isFinite(startedAt)) {
+      return;
+    }
+    rememberSession(account.address, {
+      serviceId: jobServiceId,
+      expiresAt: jobExpiresAt,
+      startedAt,
+      status: jobStatus,
+      label: serviceName,
+      href: router.asPath,
+    });
+  }, [jobServiceId, jobExpiresAt, jobStatus, jobDateCreated, account.address, serviceName, router.asPath]);
+
+  // Deep-linked from an expiry warning: land straight on the prolong modal. Waits for canProlong —
+  // the payment token and booked resources are both seeded asynchronously from the polled job — and
+  // fires once, so dismissing the modal doesn't reopen it on the next render.
+  const autoProlongedRef = useRef(false);
+  useEffect(() => {
+    if (router.query.openProlong !== '1' || autoProlongedRef.current || !canProlong) {
+      return;
+    }
+    autoProlongedRef.current = true;
+    setProlongOpen(true);
+  }, [router.query.openProlong, canProlong]);
 
   /**
    * Prolong → straight to payment for the extra runtime only. Same selection (env/token/gpu/models),
@@ -628,6 +656,10 @@ const ManageServicePage: React.FC = () => {
                 totalSeconds={durationTotalSeconds}
               />
             )}
+
+            {/* Opt-in for an OS-level alert, so the warning lands even when this tab isn't focused.
+                Offered here because this is the moment it is easiest to say yes to. */}
+            {job && !isExpired && durationTotalSeconds > 0 && <SessionAlertsToggle />}
 
             <div className="actionsGroupMdBetween">
               <div className="actionsGroupMdEnd">

--- a/src/components/inference/session-alerts-toggle.module.css
+++ b/src/components/inference/session-alerts-toggle.module.css
@@ -1,0 +1,16 @@
+.row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.icon {
+  flex-shrink: 0;
+}
+
+.note {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}

--- a/src/components/inference/session-alerts-toggle.tsx
+++ b/src/components/inference/session-alerts-toggle.tsx
@@ -1,0 +1,89 @@
+import Button from '@/components/button/button';
+import { enableNotifications, isOptedIn, isSupported, notifyState, NotifyState, setOptedIn } from '@/lib/notifications';
+import { useOceanAccount } from '@/lib/use-ocean-account';
+import NotificationsActiveOutlinedIcon from '@mui/icons-material/NotificationsActiveOutlined';
+import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
+import { useEffect, useState } from 'react';
+import styles from './session-alerts-toggle.module.css';
+
+/**
+ * Opt-in for OS notifications about this session's expiry.
+ *
+ * Placed beside the countdown so the ask lands at the moment it is easiest to say yes to — money has
+ * just been committed to a clock. Never prompts on its own: the permission is spent once and a
+ * refusal cannot be revisited, and Chrome demotes the prompt on origins that ask carelessly.
+ */
+const SessionAlertsToggle: React.FC = () => {
+  const { account } = useOceanAccount();
+  const address = account.address;
+
+  // Permission and localStorage are client-only, so start neutral and resolve after mount — keeps
+  // the server render and the first client render identical.
+  const [state, setState] = useState<NotifyState>('unsupported');
+  const [optedIn, setLocalOptedIn] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    setState(notifyState());
+    setLocalOptedIn(isOptedIn(address));
+  }, [address]);
+
+  if (!isSupported() || state === 'unsupported') {
+    return null;
+  }
+
+  if (state === 'denied') {
+    return (
+      <div className={styles.note}>
+        Notifications are blocked for this site — the in-app warning will still appear while the dashboard is open.
+      </div>
+    );
+  }
+
+  if (state === 'granted' && optedIn) {
+    return (
+      <div className={styles.row}>
+        <NotificationsActiveOutlinedIcon className={styles.icon} fontSize="small" />
+        <span className={styles.note}>You&apos;ll be notified 10 minutes before this session ends.</span>
+        <Button
+          onClick={() => {
+            setOptedIn(address, false);
+            setLocalOptedIn(false);
+          }}
+          size="sm"
+          variant="transparent"
+        >
+          Turn off
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.row}>
+      <Button
+        contentBefore={<NotificationsNoneOutlinedIcon />}
+        loading={busy}
+        onClick={async () => {
+          setBusy(true);
+          // Called straight out of the click so the gesture is still live — Safari shows no prompt
+          // otherwise.
+          const next = await enableNotifications();
+          setState(next);
+          if (next === 'granted') {
+            setOptedIn(address, true);
+            setLocalOptedIn(true);
+          }
+          setBusy(false);
+        }}
+        size="sm"
+        variant="outlined"
+      >
+        Notify me before this ends
+      </Button>
+      <span className={styles.note}>Alerts you even when this tab isn&rsquo;t the one you&rsquo;re looking at.</span>
+    </div>
+  );
+};
+
+export default SessionAlertsToggle;

--- a/src/components/inference/session-expiry-notifier.module.css
+++ b/src/components/inference/session-expiry-notifier.module.css
@@ -1,0 +1,37 @@
+.root {
+  margin-top: 16px;
+  padding: 12px 16px;
+  text-align: left;
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+
+    .icon {
+      flex-shrink: 0;
+    }
+
+    .message {
+      flex: 1;
+      min-width: 240px;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    .countdown {
+      font-variant-numeric: tabular-nums;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .action {
+      flex-shrink: 0;
+    }
+
+    .close {
+      flex-shrink: 0;
+    }
+  }
+}

--- a/src/components/inference/session-expiry-notifier.tsx
+++ b/src/components/inference/session-expiry-notifier.tsx
@@ -1,0 +1,137 @@
+import Button from '@/components/button/button';
+import Card from '@/components/card/card';
+import Container from '@/components/container/container';
+import useSessionExpiryWarnings, { ExpiringSession } from '@/hooks/use-session-expiry-warnings';
+import { ensureRegistration, isOptedIn, showSessionNotification } from '@/lib/notifications';
+import { useOceanAccount } from '@/lib/use-ocean-account';
+import { prolongHref, URGENT_BAND_SECONDS } from '@/services/session-expiry';
+import { formatHMS } from '@/utils/formatters';
+import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined';
+import CloseIcon from '@mui/icons-material/Close';
+import { IconButton } from '@mui/material';
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+import { toast } from 'react-toastify';
+import styles from './session-expiry-notifier.module.css';
+
+/** Identity of one warning. Including `expiresAt` means a prolong re-arms every band for free. */
+function warningKey(session: ExpiringSession): string {
+  return `${session.serviceId}:${session.expiresAt}:${session.band}`;
+}
+
+function toastMessage(session: ExpiringSession): string {
+  return session.band <= URGENT_BAND_SECONDS
+    ? 'ends in under a minute. Save your work — the endpoint will stop responding.'
+    : 'ends in about 10 minutes. Prolong it to keep it running.';
+}
+
+/**
+ * App-wide expiry warnings: a banner that persists, a toast on each threshold crossing, and — for
+ * anyone who opted in — an OS notification so the message lands while the tab is not being looked at.
+ *
+ * Mounted in RootLayout rather than behind a new context provider: it renders inside every provider
+ * already, and the only consumer of this state is the component rendering it.
+ */
+const SessionExpiryNotifier: React.FC = () => {
+  const { expiring, dismiss } = useSessionExpiryWarnings();
+  const { account } = useOceanAccount();
+  const address = account.address;
+
+  // A reload clears whatever the worker registered last time, so re-establish it for anyone who has
+  // opted in — otherwise `showNotification` has nothing to talk to until they revisit a manage page.
+  useEffect(() => {
+    if (isOptedIn(address)) {
+      ensureRegistration().catch(() => {
+        // Blocked worker; the banner and toast still work.
+      });
+    }
+  }, [address]);
+
+  // Mirror for the delivery effect below. Declared BEFORE it so it is already current when that
+  // effect runs in the same commit.
+  const expiringRef = useRef(expiring);
+  useEffect(() => {
+    expiringRef.current = expiring;
+  }, [expiring]);
+
+  const firedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    firedRef.current = new Set();
+  }, [address]);
+
+  // Depends on the joined key string rather than the array, so it runs on a band transition instead
+  // of once a second.
+  const bandKey = expiring.map(warningKey).join('|');
+  useEffect(() => {
+    for (const session of expiringRef.current) {
+      const key = warningKey(session);
+      if (firedRef.current.has(key)) {
+        continue;
+      }
+      firedRef.current.add(key);
+
+      toast.warning(
+        <span>
+          <strong>{session.label}</strong> {toastMessage(session)}{' '}
+          <Link href={prolongHref(session)}>Prolong session</Link>
+        </span>,
+        {
+          // Load-bearing: without an id a re-render storm stacks identical warnings.
+          toastId: key,
+          // A warning that closes itself while the tab is in the background is no warning at all.
+          autoClose: false,
+        }
+      );
+
+      if (isOptedIn(address)) {
+        void showSessionNotification({
+          title:
+            session.band <= URGENT_BAND_SECONDS ? 'Session ending in under a minute' : 'Session ending in 10 minutes',
+          body: `${session.label} — ${
+            session.band <= URGENT_BAND_SECONDS
+              ? 'the endpoint is about to stop responding.'
+              : 'prolong it to keep it running.'
+          }`,
+          // Stable per session, so the one-minute warning replaces the ten-minute one.
+          tag: `session-${session.serviceId}`,
+          url: prolongHref(session),
+        });
+      }
+    }
+  }, [bandKey, address]);
+
+  const soonest = expiring[0];
+  if (!soonest) {
+    return null;
+  }
+
+  const urgent = soonest.band <= URGENT_BAND_SECONDS;
+
+  return (
+    <Container>
+      <Card className={styles.root} direction="column" radius="md" role="status" variant={urgent ? 'error' : 'warning'}>
+        <div className={styles.row}>
+          <AccessTimeOutlinedIcon className={styles.icon} />
+          <span className={styles.message}>
+            <strong>{soonest.label}</strong> ends in{' '}
+            <span className={styles.countdown}>{formatHMS(soonest.remainingSeconds)}</span>
+            {expiring.length > 1 ? ` · ${expiring.length - 1} more ending soon` : null}
+          </span>
+          <Button className={styles.action} href={prolongHref(soonest)} size="sm" variant="outlined">
+            Prolong session
+          </Button>
+          <IconButton
+            aria-label="Dismiss session expiry warning"
+            className={styles.close}
+            onClick={() => dismiss(soonest)}
+            size="small"
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </div>
+      </Card>
+    </Container>
+  );
+};
+
+export default SessionExpiryNotifier;

--- a/src/hooks/use-session-expiry-warnings.ts
+++ b/src/hooks/use-session-expiry-warnings.ts
@@ -1,0 +1,113 @@
+import { useOceanAccount } from '@/lib/use-ocean-account';
+import {
+  bandFor,
+  readSessions,
+  REGISTRY_EVENT,
+  rememberSession,
+  TrackedSession,
+  WARN_WINDOW_SECONDS,
+} from '@/services/session-expiry';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export type ExpiringSession = TrackedSession & {
+  remainingSeconds: number;
+  band: number;
+};
+
+/** 1Hz only while something is actually inside the warning window. */
+const TICK_ACTIVE_MS = 1000;
+/** Otherwise a slow heartbeat, so a live 1-hour session doesn't re-render app-wide chrome 3600 times. */
+const TICK_IDLE_MS = 15000;
+
+/**
+ * Watches every tracked session's deadline and reports the ones inside a warning band.
+ *
+ * The one rule that makes this work: **never count intervals**. `remaining` is always
+ * `expiresAt - Date.now()`, and the interval exists only to schedule a re-render. Browsers clamp
+ * hidden-tab timers to one tick a minute (Chrome, after 5 minutes hidden) or pause them outright
+ * (Safari), so a counter that accumulated ticks would drift far enough to never reach the threshold
+ * at all. Reading the clock instead makes a throttled tab produce a *late render* of a *correct
+ * value*, and the visibility listeners force that render the instant the tab is looked at again.
+ *
+ * Pure state — delivery (banner, toast, OS notification) belongs to the notifier component.
+ */
+export default function useSessionExpiryWarnings(): {
+  expiring: ExpiringSession[];
+  dismiss: (session: ExpiringSession) => void;
+} {
+  const { account } = useOceanAccount();
+  const address = account.address;
+
+  // Registry snapshot. Read only in effects, so the server render and the first client render both
+  // see [] and there's no hydration mismatch (same approach as legacy-escrow-banner).
+  const [sessions, setSessions] = useState<TrackedSession[]>([]);
+  useEffect(() => {
+    if (!address) {
+      setSessions([]);
+      return;
+    }
+    const sync = () => setSessions(readSessions(address));
+    sync();
+    window.addEventListener('storage', sync); // another tab wrote
+    window.addEventListener(REGISTRY_EVENT, sync); // this tab wrote
+    return () => {
+      window.removeEventListener('storage', sync);
+      window.removeEventListener(REGISTRY_EVENT, sync);
+    };
+  }, [address]);
+
+  const [now, setNow] = useState(() => Date.now());
+
+  const soonestRemaining = useMemo(
+    () => sessions.reduce((min, session) => Math.min(min, (session.expiresAt - now) / 1000), Number.POSITIVE_INFINITY),
+    [sessions, now]
+  );
+
+  const tickMs = soonestRemaining <= WARN_WINDOW_SECONDS ? TICK_ACTIVE_MS : TICK_IDLE_MS;
+
+  useEffect(() => {
+    if (sessions.length === 0) {
+      return;
+    }
+    const resync = () => setNow(Date.now());
+    const timer = setInterval(resync, tickMs);
+    // The interval alone is not enough: it can be throttled or paused while hidden. These force an
+    // immediate recompute the moment the tab is looked at again. `pageshow` covers a Safari bfcache
+    // restore, where neither of the others reliably fires.
+    document.addEventListener('visibilitychange', resync);
+    window.addEventListener('focus', resync);
+    window.addEventListener('pageshow', resync);
+    return () => {
+      clearInterval(timer);
+      document.removeEventListener('visibilitychange', resync);
+      window.removeEventListener('focus', resync);
+      window.removeEventListener('pageshow', resync);
+    };
+  }, [tickMs, sessions.length]);
+
+  const expiring = useMemo(
+    () =>
+      sessions
+        .map((session) => {
+          const remainingSeconds = Math.floor((session.expiresAt - now) / 1000);
+          return { ...session, remainingSeconds, band: bandFor(session, remainingSeconds) };
+        })
+        .filter(
+          (session): session is ExpiringSession => session.band !== null && session.dismissedBand !== session.band
+        )
+        .sort((a, b) => a.remainingSeconds - b.remainingSeconds),
+    [sessions, now]
+  );
+
+  // Persisted on the record rather than in component state, so it survives a reload and syncs to
+  // other tabs through the storage event. Storing the *band* is what lets the final warning break
+  // through an earlier dismissal: dismissing at T-10 sets 600, and at T-1 the band is 60.
+  const dismiss = useCallback(
+    (session: ExpiringSession) => {
+      rememberSession(address, { serviceId: session.serviceId, dismissedBand: session.band });
+    },
+    [address]
+  );
+
+  return { expiring, dismiss };
+}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,124 @@
+/**
+ * OS-level notifications for session expiry.
+ *
+ * Everything goes through the service worker's `showNotification`, never the page-level
+ * `new Notification()` constructor — that throws outright on Chrome for Android, and notification
+ * action buttons and click handling only exist on the worker path anyway.
+ */
+
+const SW_URL = '/sw.js';
+
+/** Opt-in flag, per wallet. Permission alone isn't consent to notify about *this* session. */
+const OPT_IN_PREFIX = 'session-expiry-notify';
+
+export type NotifyState = 'unsupported' | 'default' | 'granted' | 'denied';
+
+function optInKey(address: string): string {
+  return `${OPT_IN_PREFIX}-${address.toLowerCase()}`;
+}
+
+export function isSupported(): boolean {
+  return (
+    typeof window !== 'undefined' && 'Notification' in window && 'serviceWorker' in navigator && window.isSecureContext
+  );
+}
+
+export function notifyState(): NotifyState {
+  if (!isSupported()) {
+    return 'unsupported';
+  }
+  return Notification.permission as NotifyState;
+}
+
+export function isOptedIn(address?: string): boolean {
+  if (!address) {
+    return false;
+  }
+  try {
+    return localStorage.getItem(optInKey(address)) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function setOptedIn(address: string | undefined, value: boolean): void {
+  if (!address) {
+    return;
+  }
+  try {
+    localStorage.setItem(optInKey(address), value ? 'true' : 'false');
+  } catch {
+    // Best-effort; without persistence the toggle just doesn't survive a reload.
+  }
+}
+
+let registration: Promise<ServiceWorkerRegistration> | null = null;
+
+/**
+ * Register (once) and resolve when the worker is usable. Only ever called for someone who has opted
+ * in — there's no reason to hand every visitor a service worker.
+ */
+export function ensureRegistration(): Promise<ServiceWorkerRegistration> {
+  if (!registration) {
+    registration = navigator.serviceWorker.register(SW_URL).then(() => navigator.serviceWorker.ready);
+  }
+  return registration;
+}
+
+/**
+ * Ask for permission and register the worker.
+ *
+ * MUST be called synchronously from a real user gesture: Safari shows no prompt at all otherwise,
+ * and a refusal is permanent per origin — it cannot be asked for a second time. Chrome additionally
+ * demotes the prompt on origins with poor accept rates, so this belongs behind an explicit control
+ * shown at a moment that earns it, never on page load.
+ */
+export async function enableNotifications(): Promise<NotifyState> {
+  if (!isSupported()) {
+    return 'unsupported';
+  }
+  const permission = Notification.permission === 'granted' ? 'granted' : await Notification.requestPermission();
+  if (permission !== 'granted') {
+    return permission as NotifyState;
+  }
+  try {
+    await ensureRegistration();
+  } catch {
+    // Registration can fail (blocked worker, private mode). Permission is still granted; the
+    // in-app banner keeps working, so report the grant rather than inventing a denial.
+  }
+  return 'granted';
+}
+
+/**
+ * Show one expiry notification. Returns false when it couldn't be shown, so the caller can rely on
+ * the in-app banner alone.
+ */
+export async function showSessionNotification(options: {
+  title: string;
+  body: string;
+  /** Stable per session, so a later warning REPLACES an earlier one instead of stacking. */
+  tag: string;
+  url: string;
+}): Promise<boolean> {
+  if (!isSupported() || Notification.permission !== 'granted') {
+    return false;
+  }
+  try {
+    const ready = await ensureRegistration();
+    await ready.showNotification(options.title, {
+      body: options.body,
+      tag: options.tag,
+      data: { url: options.url },
+      icon: '/logo.svg',
+      badge: '/logo.svg',
+      // Same tag replaces silently by default; this makes the T-1 warning actually alert.
+      renotify: true,
+      // The whole scenario is a machine nobody is sitting at, so it must not auto-dismiss.
+      requireInteraction: true,
+    } as NotificationOptions);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/services/session-expiry.ts
+++ b/src/services/session-expiry.ts
@@ -1,0 +1,152 @@
+/**
+ * Registry of every service session this browser has seen, so an expiry warning can follow the user
+ * across pages instead of living only on the manage page's countdown bar.
+ *
+ * Deliberately localStorage rather than a fetch: the manage page already polls the node every 4s and
+ * holds its authoritative `expiresAt`, so recording from there costs one effect, needs no auth, and
+ * can't be made stale by a backend record the node hasn't reconciled yet. It also makes every state
+ * seedable from the console — the only way this is testable in a repo with no test harness.
+ */
+
+export type TrackedSession = {
+  serviceId: string;
+  /** Epoch MS, straight off the node's job record (`job.expiresAt`). */
+  expiresAt: number;
+  /** Epoch MS, `job.dateCreated` parsed. Sizes the bands — see `bandFor`. */
+  startedAt: number;
+  /** Manage-page URL as recorded, so the warning's CTA can deep-link back with full query state. */
+  href: string;
+  /** Service / template / model name, for the warning copy. */
+  label: string;
+  /** `ServiceStatusNumber`, last seen. */
+  status?: number;
+  /** Band the user dismissed in, so a later (narrower) band still breaks through. */
+  dismissedBand?: number;
+};
+
+/**
+ * Seconds-remaining thresholds, widest first.
+ *
+ * 600 is actionable: prolonging routes through an escrow top-up and up to two on-chain
+ * confirmations, which is 1–5 minutes, so ten leaves roughly 2x headroom. 60 is terminal — not
+ * "you can still extend" but "the endpoint is about to stop answering".
+ */
+export const WARN_BANDS_SECONDS = [600, 60] as const;
+
+/** The widest band — outside this, nothing needs a 1Hz clock. */
+export const WARN_WINDOW_SECONDS = WARN_BANDS_SECONDS[0];
+
+/** The narrowest band, rendered as an error rather than a warning. */
+export const URGENT_BAND_SECONDS = WARN_BANDS_SECONDS[WARN_BANDS_SECONDS.length - 1];
+
+/**
+ * A band only arms if the session's whole window was meaningfully longer than it — otherwise a
+ * 5-minute session would fire its "10 minutes left" warning the instant it launched.
+ */
+const BAND_MIN_TOTAL_RATIO = 1.5;
+
+/** Entries are dropped this long after their deadline, so the registry can't grow forever. */
+const RETENTION_MS = 60 * 60 * 1000;
+
+/**
+ * Same-tab change notification. The `storage` event fires in *other* tabs only, so a write here
+ * would otherwise be invisible to the notifier mounted in this one.
+ */
+export const REGISTRY_EVENT = 'session-expiry-updated';
+
+/**
+ * Injected wallets hand back checksummed addresses while the services API is called lowercased, and
+ * the same account can surface either way. Key without normalising and the registry silently
+ * orphans itself on reconnect — the sessions are still there, under an address that no longer
+ * matches. See the same discipline in `context/node-tokens`.
+ */
+function storageKey(address: string): string {
+  return `session-expiry-${address.toLowerCase()}`;
+}
+
+/** Every tracked session for `address`, expired-and-stale entries already dropped. */
+export function readSessions(address?: string): TrackedSession[] {
+  if (!address) {
+    return [];
+  }
+  try {
+    const raw = localStorage.getItem(storageKey(address));
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as Record<string, TrackedSession>;
+    const cutoff = Date.now() - RETENTION_MS;
+    return Object.values(parsed).filter(
+      (session) =>
+        !!session &&
+        typeof session.serviceId === 'string' &&
+        Number.isFinite(session.expiresAt) &&
+        session.expiresAt > cutoff
+    );
+  } catch {
+    // Corrupt payload, or localStorage throwing outright (Safari private mode, restricted iframe).
+    // The feature no-ops rather than taking the page down with it.
+    return [];
+  }
+}
+
+/**
+ * Merge one session in.
+ *
+ * `expiresAt` only ever moves forward — extending pushes it out and nothing moves it back — so
+ * `max()` is provably safe and no stale writer can shorten a deadline. That also makes a forward
+ * jump unambiguous evidence of a prolong, which is why it clears the dismissal: every band re-arms
+ * itself for the new deadline with no reset logic anywhere.
+ */
+export function rememberSession(
+  address: string | undefined,
+  next: Partial<TrackedSession> & { serviceId: string }
+): void {
+  if (!address) {
+    return;
+  }
+  try {
+    const byId = Object.fromEntries(readSessions(address).map((session) => [session.serviceId, session]));
+    const prev = byId[next.serviceId];
+    const merged = {
+      ...prev,
+      ...next,
+      expiresAt: Math.max(prev?.expiresAt ?? 0, next.expiresAt ?? 0),
+    } as TrackedSession;
+    if (prev && merged.expiresAt > prev.expiresAt) {
+      delete merged.dismissedBand;
+    }
+    byId[next.serviceId] = merged;
+    localStorage.setItem(storageKey(address), JSON.stringify(byId));
+    window.dispatchEvent(new Event(REGISTRY_EVENT));
+  } catch {
+    // Persistence is best-effort; a blocked store just means no cross-page warning.
+  }
+}
+
+/**
+ * The narrowest band `remainingSeconds` has fallen inside, or null when the session is outside the
+ * warning window, already expired, or too short for any band to have armed.
+ */
+export function bandFor(session: TrackedSession, remainingSeconds: number): number | null {
+  if (remainingSeconds <= 0) {
+    return null;
+  }
+  const totalSeconds = (session.expiresAt - session.startedAt) / 1000;
+  // Narrowest first, so a session inside both bands reports 60 rather than 600.
+  for (const band of [...WARN_BANDS_SECONDS].sort((a, b) => a - b)) {
+    if (remainingSeconds <= band) {
+      return totalSeconds > band * BAND_MIN_TOTAL_RATIO ? band : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * CTA target: the recorded manage-page URL, flagged so the page opens with the prolong modal already
+ * up. Deliberately a different param from the payment page's own `prolong=1`.
+ */
+export function prolongHref(session: TrackedSession): string {
+  const base = session.href.replace(/([?&])openProlong=1&?/, '$1').replace(/[?&]$/, '');
+  return base.includes('?') ? `${base}&openProlong=1` : `${base}?openProlong=1`;
+}

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -112,7 +112,12 @@ export const formatWalletAddress = (address: string): string => {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };
 
-const formatHMS = (sec: number): string => {
+/**
+ * Seconds as HH:MM:SS. Clamped at zero so a live countdown that momentarily reads negative (the
+ * local tick can run a hair past the authoritative deadline) renders 00:00:00 rather than -00:00:01.
+ */
+export const formatHMS = (totalSeconds: number): string => {
+  const sec = Math.max(0, Math.floor(totalSeconds));
   const h = Math.floor(sec / 3600);
   const m = Math.floor((sec % 3600) / 60);
   const s = sec % 60;


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

Sessions end silently today — the only warning is a countdown bar that lives on the manage page, so
navigating away (let alone hiding or closing the tab) means no signal at all.

This adds two of three planned phases. Phase 3 (scheduled web push, for a *closed* tab) is deliberately
out of scope here.

### Phase 1 — in-app, app-wide
- New per-wallet session store in `localStorage`, written from the manage page's existing 4s node poll
- New `useSessionExpiryWarnings` hook: warns at **T−10min** (actionable) and **T−1min** (terminal)
- New `<SessionExpiryNotifier />` mounted in `RootLayout` — banner + toast on every page
- Banner CTA deep-links back with `?openProlong=1`, opening the prolong modal directly

### Phase 2 — out of the tab
- Minimal service worker (`public/sw.js`) turning the same trigger into an OS notification
- Opt-in control beside the countdown; permission is only ever requested from a real click
- `notificationclick` focuses the existing dashboard tab instead of piling up new ones


<img width="1458" height="884" alt="Screenshot 2026-08-27 at 11 48 16" src="https://github.com/user-attachments/assets/b91fc3a3-b9ad-4a72-8a5c-5a3b2cc314ce" />
<img width="1191" height="658" alt="Screenshot 2026-08-27 at 11 06 50" src="https://github.com/user-attachments/assets/edc44196-b3e9-4bd7-bb45-5640c46563d4" />
<img width="1419" height="364" alt="Screenshot 2026-08-27 at 11 46 48" src="https://github.com/user-attachments/assets/647fa39d-9ff7-4c94-a9d1-bda9379e8694" />

